### PR TITLE
Logo - Remove id, add aria-labelledby and role

### DIFF
--- a/components/03 - global/logo/logo.twig
+++ b/components/03 - global/logo/logo.twig
@@ -1,7 +1,7 @@
 <div class="logo {{ logo_color }} {{ logo_classes }}">
 	<a href="{{ path }}">
 		<div class="element-invisible">The University of Iowa</div>
-		<svg class="logo-icon" id="logo" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 611 195">
+		<svg class="logo-icon" aria-labelledby="uiowa-wordmark" role="img" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewbox="0 0 611 195">
 			<path class="st0" d="M98.83 11.09H24.1v35.24h13.58v97.94H24.1v35.48h74.72v-35.48H85.24V46.34h13.59V11.09zM230.8 145.73V45.12c0-20.9-12.86-34.03-32.51-34.03h-54.11c-19.41 0-32.51 13.13-32.51 34.03v100.61c0 21.14 12.86 34.02 32.51 34.02h54.11c19.41.01 32.51-13.11 32.51-34.02m-71.32-99.39h23.54v97.94h-23.54V46.34zm116.93 133.42h54.83l22.56-99.4 22.08 99.4h57.01L454 46.34h11.65V11.09h-69.87v35.24h12.37l-9.71 81.17-26.92-116.41h-35.91L310.38 127.5l-12.13-81.17h13.34V11.09h-70.84v35.24h11.89l23.77 133.43zm173.71 0h56.04l5.1-41.07h28.38l5.34 41.07H602v-35.48h-11.89L564.88 11.09h-76.42l-25.47 133.18h-12.86v35.49zm64.54-71.94l11.16-68.05 10.91 68.05h-22.07z"/>
       <image src="{{ logo_path_png }}" xlink:href="">
       	<title id="uiowa-wordmark">University of Iowa</title>


### PR DESCRIPTION
resolves #133

There is still a duplicative id with `uiowa-wordmark` that gets flagged, but unless we create separate svgs for each implementation (header/footer) this still dings us. separate svg components slow performance.