### PR TITLE
tweak a11y related to search-toggle

### DIFF
--- a/src/components/search-toggle/_search-toggle.scss
+++ b/src/components/search-toggle/_search-toggle.scss
@@ -102,7 +102,7 @@
     }
   }
 
-  &[aria-expanded="true"] {
+  &[aria-hidden="false"] {
     background: $white;
 
     @include breakpoint(menu) {
@@ -347,7 +347,7 @@
 
 
 
-  &[aria-expanded="true"] {
+  &[aria-hidden="false"] {
     z-index: 1;
     visibility: visible;
     transition: opacity .3s;
@@ -452,7 +452,7 @@
     background-color: $white;
   }
 
-  &[aria-expanded="true"] {
+  &[aria-hidden="false"] {
     z-index: 1;
     top: 0;
     display: contents;

--- a/src/components/search-toggle/_search-toggle.scss
+++ b/src/components/search-toggle/_search-toggle.scss
@@ -102,7 +102,7 @@
     }
   }
 
-  &[aria-hidden="false"] {
+  &[aria-expanded="true"] {
     background: $white;
 
     @include breakpoint(menu) {

--- a/src/components/search-toggle/search-toggle--bttn.twig
+++ b/src/components/search-toggle/search-toggle--bttn.twig
@@ -1,4 +1,4 @@
-<button type="button" class="search-button" role="button" aria-expanded="false" aria-labelledby="search-button-label">
+<button type="button" class="search-button" role="button" aria-expanded="false" aria-controls="search-overlay" aria-labelledby="search-button-label">
 	<span id="search-button-label">Search</span>
 </button>
 

--- a/src/components/search-toggle/search-toggle--overlay.twig
+++ b/src/components/search-toggle/search-toggle--overlay.twig
@@ -1,4 +1,4 @@
-<div class="search-overlay" aria-expanded="false" aria-label="search tools for this site">
+<div id="search-overlay" class="search-overlay" aria-hidden="true" aria-label="search tools for this site">
 	{% include '@search' %}
 	{% if search_type == 'search--primary' %}
 		{% block search %}

--- a/src/components/search-toggle/search-toggle.js
+++ b/src/components/search-toggle/search-toggle.js
@@ -13,7 +13,7 @@ if (document.querySelector(".search-button")) {
         this.setAttribute("aria-expanded", "false");
         document
           .querySelector(".search-overlay")
-          .setAttribute("aria-expanded", "false");
+          .setAttribute("aria-hidden", "true");
       }
     });
 }
@@ -22,16 +22,12 @@ function searchToggle() {
   if (document.getElementById("search-button-label")) {
     if (body.classList.contains("search-is-open")) {
       this.setAttribute("aria-expanded", "false");
-      wrapper.setAttribute("aria-expanded", "false");
+      wrapper.setAttribute("aria-hidden", "true");
       body.classList.remove("search-is-open");
     } else {
-      wrapper.setAttribute("aria-expanded", "true");
+      wrapper.setAttribute("aria-hidden", "false");
       this.setAttribute("aria-expanded", "true");
       body.classList.add("search-is-open");
-    }
-  if (button.getAttribute("aria-expanded") === "true") {
-      document.getElementsByName('search-terms')[0].focus();
-    } else {
     }
   }
 }
@@ -45,7 +41,7 @@ document.addEventListener(
       if (document.getElementById("search-button-label")) {
         document.body.classList.remove("search-is-open");
         document.getElementById("search-button-label").innerHTML = "Search";
-        wrapper.setAttribute("aria-expanded", "false");
+        wrapper.setAttribute("aria-hidden", "true");
         button.setAttribute("aria-expanded", "false");
       }
     }

--- a/src/components/search-toggle/search-toggle.twig
+++ b/src/components/search-toggle/search-toggle.twig
@@ -1,5 +1,5 @@
 <div class="search-wrapper">
-{% include "@search-toggle--overlay" %}
 {% include "@search-toggle--bttn" %}
+{% include "@search-toggle--overlay" %}
 </div>
 


### PR DESCRIPTION
This PR attempts to resolve the a11y issue reported by @inspector508 along with some other tweaks:

>Search button doesn’t announce changes in aria-expanded value.

https://github.com/uiowa/uiowa/issues/1437#issuecomment-634686264

The initial problem appears to be that the current implementation forces a focus change to the search input before the aria-expanded value on the toggle button is announced. The force focus change was done to lead the user back up the DOM where the search input is instead of out to the next element (main menu).

I changed the DOM order after talking with @bspeare and removed the forced focus change. I also added similar aria-controls information to the markup similar to the accordion component. I also believe there was misuse of `aria-expanded` on the search-overlay element where aria-hidden makes more sense. The css targeting the aria-expanded attribute had to be changed.

To Test:
- Pull branch, build, start.
- Go to http://localhost:3000/components/preview/header-old--default and try out the updated behavior
- Check to make sure you can still click out of the the search area to close the search area.

Below is a screencast demonstrating current behavior followed by the change. Notice on the current behavior the button expanded is not announced and focus immediately switches to the search input. The updated example announces the expanded change and allows natural tab navigation to the search input.

[OneDrive video link](https://iowa-my.sharepoint.com/:v:/g/personal/jwhitsit_uiowa_edu/EWbPXa--SmJGr_ZEN0pS5KABFjyIS7HtSieXPwmBW95QRg?e=2Ucd9a)