### PR TITLE
Feature: Quick fixes for a 3.0.1 release

### DIFF
--- a/src/components/hero/_hero.scss
+++ b/src/components/hero/_hero.scss
@@ -180,16 +180,6 @@ img.hero-image {
   margin-right: 0;
 }
 
-.hero.hero__center {
-  p {
-    margin: 0 $mobile-width-gutter;
-    @include breakpoint(sm) {
-      margin: 0;
-    }
-  }
-}
-
-
 
 .hero {
   p {


### PR DESCRIPTION
- Removed hero-center style targeting centered text margins

# How to test

Verify that hero center paragraph text does not look off centered. 