### PR TITLE
Feature: Events component fix

### DIFF
--- a/src/components/event/event.config.yml
+++ b/src/components/event/event.config.yml
@@ -1,8 +1,12 @@
 title: Events Block
 order: 3
 status: wip
-hidden: true
+hidden: false
 name: Events Block
+meta:
+  dependencies:
+    stylesheets:
+      - /components/colors/colors.css
 context:
   events:
     items:
@@ -10,21 +14,21 @@ context:
         events_card_title: College of Liberal Arts and Sciences 9 a.m. Commencement Ceremony
         events_card_link_title: Read Article
         events_card_link_url: https://uiowa.edu/
-        events_card_image: ../../images/events-01.jpg
+        events_card_image: '../../assets/images/events-01.jpg'
         events_card_text: Molecular medicine PhD student Jordan Kohlmeyer is researching new therapies for malignant peripheral nerve sheath tumors, which are deadly, resistant to drug therapies, and often unable to be operated upon due to their location.
         events_card_date: May 16, 2020, 9:00 AM
       - events_card_tag: Carver-Hawkeye Arena
         events_card_title: College of Engineering 9 a.m. Commencement Ceremony
         events_card_link_title: Read Article
         events_card_link_url: https://uiowa.edu/
-        events_card_image: ../../images/events-02.jpg
+        events_card_image: '../../assets/images/events-02.jpg'
         events_card_text: Receiving a diploma signals both an ending and a beginning.
         events_card_date: May 17, 2020, 9:00 AM
       - events_card_tag: Carver-Hawkeye Arena
         events_card_title: College of Education 9 a.m. Commencement Ceremony
         events_card_link_title: Read Article
         events_card_link_url: https://uiowa.edu/
-        events_card_image: ../../images/events-03.jpg
+        events_card_image:
         events_card_text: As the attending veterinarian at a marine mammal hospital in Los Angeles, University of Iowa alumna Lauren Palmer aims to rehabilitate and release sick or injured animals—and to help educate people about the ocean’s ecosystem.
         events_card_date: May 18, 2020, 9:00 AM
 

--- a/src/components/event/event.config.yml
+++ b/src/components/event/event.config.yml
@@ -1,7 +1,7 @@
 title: Events Block
 order: 3
 status: wip
-hidden: false
+hidden: true
 name: Events Block
 meta:
   dependencies:

--- a/src/components/event/event.scss
+++ b/src/components/event/event.scss
@@ -13,11 +13,9 @@
 
     @include breakpoint(sm) {
       text-align: center;
-      width: 100%;
     }
 
     @include breakpoint(container) {
-      width: 70%;
       padding: 0;
       text-align: left;
       ;

--- a/src/components/event/event.twig
+++ b/src/components/event/event.twig
@@ -1,4 +1,4 @@
-<div class="events-card__wrapper uids-component--gold">
+<div class="events-card__wrapper bg--gold">
 
 	{% set events_card_position = 0 %}
 


### PR DESCRIPTION
resolves #276

# How to test

Go to https://uids.brand.uiowa.edu/branches/feature_event_fallback_updates/components/detail/events-block.html and verify that an event without an image appears full-width of it's row container. 

<img width="1807" alt="Screen Shot 2020-07-09 at 11 52 35 AM" src="https://user-images.githubusercontent.com/1036433/87068405-1dca0980-c1db-11ea-881d-0051aab41388.png">
