### PR TITLE
Feature: Accordion content text size and padding adjustments

### DIFF
--- a/src/components/accordion/accordion.scss
+++ b/src/components/accordion/accordion.scss
@@ -63,11 +63,7 @@
   }
 
   .accordion__content {
-    padding: $sm $md;
+    padding: $md;
     border: 1px solid #edeceb;
-
-    p {
-      font-size: inherit;
-    }
   }
 }


### PR DESCRIPTION
Resolves https://github.com/uiowa/uids/issues/282. 

- Removed `font-size: inherit` for accordion `<p>` so that font sizes within the accordion will follow the same size as content within a basic text area. 

https://uids.brand.uiowa.edu/branches/feature_accordion_text/components/detail/accordion--multi.html