### PR TITLE
Feature: Hawk Alert quick fix

### DIFF
--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -77,6 +77,7 @@
       @include breakpoint(menu) {
         width: 100%;
         padding-left: $md;
+        padding-top: $xsm;
         text-align: left;
         grid-area: 2 / 2 / 3 / 5;
       }
@@ -85,6 +86,9 @@
     .hawk-alert-body {
       @include breakpoint(menu) {
         width: 100%;
+        padding-left: $md;
+        text-align: left;
+        flex-wrap: wrap;
 
         @include center(vertical);
         grid-area: 1 / 2 / 2 / 5;
@@ -92,9 +96,9 @@
 
       p {
         width: 100%;
+        margin: 0;
 
         @include breakpoint(menu) {
-          padding-left: $md;
           text-align: left;
         }
       }


### PR DESCRIPTION
It looks like the hawk alert body does not contain a `<p>` so I have adjusted so that it will work for both `<p>` and `<span>` to resolve https://github.com/uiowa/uiowa/issues/2097.