### PR TITLE
Added functionality for white, gray, light banner background

### DIFF
--- a/src/components/banner/banner.scss
+++ b/src/components/banner/banner.scss
@@ -107,7 +107,10 @@
   // @todo This should probably be resolved with https://sass-lang.com/documentation/values/maps#using-maps
   &.bg-pattern--brain,
   &.bg-pattern--brain-reversed,
-  &.bg--gold {
+  &.bg--gold,
+  &.bg--light,
+  &.bg--white,
+  &.bg--gray {
     color: $secondary;
 
     p {


### PR DESCRIPTION
Fixes pull request #2466. https://github.com/uiowa/uiowa/pull/2466

Adds white, gray, light banner background color options.