### PR TITLE
Hotfix: Display slider correctly when it is inside of a 'display: flex' container

### DIFF
--- a/src/components/slider/slider--multiple.twig
+++ b/src/components/slider/slider--multiple.twig
@@ -4,9 +4,11 @@
   {% endfor %}
 </div>
 
-<div id="slider2" class="slider slider__container slider__container-expanded">
-  {% for slide in slides | slice(0, 3) %}
-    {% include '@slider--slide' %}
-  {% endfor %}
+<div style="display: flex">
+  <div id="slider2" class="slider slider__container slider__container-expanded">
+    {% for slide in slides | slice(0, 3) %}
+      {% include '@slider--slide' %}
+    {% endfor %}
+  </div>
 </div>
 

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -8,6 +8,7 @@
 .slider {
   flex-wrap: wrap;
   @include flexbox;
+  flex-basis: 100%;
 
   @include breakpoint(sm) {
     align-content: stretch;


### PR DESCRIPTION
# To test locally
* `npm run watch`
* View https://localhost:3000/components/preview/slider--multiple and observe that the second slider is shown.