### PR TITLE
Updated button link styling to accomodate for gold based backgrounds

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -27,11 +27,12 @@
   &--tertiary {
     @include bttn--tertiary;
     @include bttn--focus;
-    border: 1px solid white;
+    background: #fff;
+    border: none;
 
     &:hover,
     &:focus {
-      border: 1px solid #999;
+      //border: 1px solid #999;
     }
   }
 
@@ -41,7 +42,11 @@
 
   &--outline {
     @include bttn--outline;
-    border: 1px solid $primary;
+    border: 1px solid;
+
+    &.bttn--tertiary {
+      background: none;
+    }
 
     &.bttn--secondary {
 
@@ -104,8 +109,7 @@
         border: 1px solid $primary;
         color: inherit;
       }
-      .bg-pattern--brain-reversed &,
-      .bg--gold--pattern--brain &,
+
       .bg--black .bg--white &,
       .bg--black--pattern--brain .bg--white &,
       .bg-pattern--brain-black .bg--white &,
@@ -271,6 +275,13 @@
 .bttn--tertiary {
   [class*=bg-] .bg--gray & {
     border-color: $secondary;
+  }
+  &:not([class*="bttn--outline"]) {
+    .bg--black--pattern--brain &,
+    .bg-pattern--brain-black &,
+    .bg--black & {
+      color: $secondary;
+    }
   }
 }
 

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -104,7 +104,8 @@
         border: 1px solid $primary;
         color: inherit;
       }
-
+      .bg-pattern--brain-reversed &,
+      .bg--gold--pattern--brain &,
       .bg--black .bg--white &,
       .bg--black--pattern--brain .bg--white &,
       .bg-pattern--brain-black .bg--white &,


### PR DESCRIPTION
https://github.com/uiowa/uiowa/issues/2566

# How to test

1. Add all button variants to kitchen sink page (https://localhost:3000/components/detail/kitchen-sink): 

```
    <a href="https://www.example.com" class="bttn bttn--tertiary bttn--caps">
      More News
      <i class="fas fa-arrow-right"></i>
    </a>
    <a href="https://www.example.com" class="bttn bttn--primary bttn--caps">
      More News
      <i class="fas fa-arrow-right"></i>
    </a>
    <a href="https://www.example.com" class="bttn bttn--secondary bttn--caps">
      More News
      <i class="fas fa-arrow-right"></i>
    </a>
    <a href="https://www.example.com" class="bttn bttn--outline bttn--tertiary bttn--caps">
      More News
      <i class="fas fa-arrow-right"></i>
    </a>
    <a href="https://www.example.com" class="bttn bttn--outline bttn--tertiary bttn--sans-serif">
      More News
      <i class="fas fa-arrow-right"></i>
    </a>
    <a href="https://www.example.com" class="bttn bttn--secondary bttn--sans-serif bttn--outline bttn--outline">
      More News
    </a>
    <a href="https://www.example.com" class="bttn bttn--link bttn--sans-serif">
      More News
      <i class="fas fa-arrow-right"></i>
    </a>
```

2. Test that first button retains white background and third button retains border. 
3. Test that card button on gold background and gold brain background retains border on kitchen sink page. 
