### PR TITLE
add primary color for mark tag

### DIFF
--- a/src/components/typography/paragraph/paragraph.scss
+++ b/src/components/typography/paragraph/paragraph.scss
@@ -64,6 +64,10 @@ sub {
   font-size: 75%;
 }
 
+mark {
+  background-color: $primary;
+}
+
 .is-small {
   font-size: $small-font-size;
 }


### PR DESCRIPTION
We currently allow the `<mark>` tag in our WYSIWYG. Reset.css makes it highlighter yellow. May I suggest an on-brand mark?

before:
<img width="256" alt="Screen Shot 2020-12-07 at 2 24 45 PM" src="https://user-images.githubusercontent.com/4663676/101401438-fb2a4280-3897-11eb-8559-0c540fb26861.png">

after:
<img width="236" alt="Screen Shot 2020-12-07 at 2 24 34 PM" src="https://user-images.githubusercontent.com/4663676/101401437-fa91ac00-3897-11eb-847b-ac3b766b1001.png">

