### PR TITLE
Feature: Fix for stat hover regression

### DIFF
--- a/src/components/stat/stat.scss
+++ b/src/components/stat/stat.scss
@@ -17,14 +17,7 @@
   &:hover .stat__content {
     @include breakpoint(menu) {
       @include element-invisible-off;
-      flex-basis: 100%;
       opacity: 1;
-    }
-  }
-
-  &.element--flex-center:hover .stat__content {
-    @include breakpoint(menu) {
-      flex-basis: 80%;
     }
   }
 }
@@ -50,11 +43,6 @@
     .element--flex-center & {
       padding: $md $lg $sm $lg;
       display: block;
-    }
-
-    .bg-pattern--brain-black &,
-    .bg--black & {
-      //color: white;
     }
 
     .bg-pattern--brain &,
@@ -92,13 +80,11 @@
     margin: 0;
     padding: 0;
     line-height: 1.4;
-    flex-basis: 80%;
 
     @include breakpoint(menu) {
       opacity: 0;
       transition: 1s;
       @include element-invisible;
-      flex-basis: 100%;
     }
 
     .bg--black &,
@@ -113,7 +99,7 @@
 
     .element--flex-center & {
       @include breakpoint(menu) {
-        flex-basis: 80%;
+        margin: 0 10%;
       }
     }
 
@@ -206,6 +192,7 @@
       padding-top: .5rem;
       margin-top: .75rem;
       border-top: 8px solid $primary;
+      flex-basis: 100%;
     }
 
   }


### PR DESCRIPTION
This pr fixes a stat regression that loses it centering if the stat contains `stat__content`. 

# How to test

Compare https://uids.brand.uiowa.edu/components/preview/stat--row.html against https://uids.brand.uiowa.edu/branches/feature_stat_regression_updates/components/preview/stat--row.html and notice how the hover in this feature branch does not pop all the way to the top of the grid container.  