### PR TITLE
Feature: Added text utility colors

### DIFF
--- a/src/components/colors/colors.scss
+++ b/src/components/colors/colors.scss
@@ -30,6 +30,22 @@
 
 // uids classes
 
+.text--gray {
+  color: $brand-cool-gray;
+}
+
+.text--gold {
+  color: $primary;
+}
+
+.text--black {
+  color: $secondary;
+}
+
+.text--white {
+  color: $white;
+}
+
 .bg--gold {
   background: $primary;
 }


### PR DESCRIPTION
This pr adds a few text utility color classes. 

# How to test

- Go to the Kitchen sink page and try adding `text--gray` to one of the headlines on a white background that isn't linked up.  The heading should change color.  