### PR TITLE
fixing table striped border issue

### DIFF
--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -148,6 +148,10 @@ table.gray-borders {
     &.table--striped {
       border: 1px solid #eee;
 
+      &.table--gray-borders {
+        border: unset;
+      }
+
       &.table--is-sticky-left.table--left-sticky-minwidth {
         table.is-striped tbody th {
           filter: drop-shadow(0px 4px 2px rgba(0, 0, 0, 0.2));


### PR DESCRIPTION
hotfix to fix sizing issue. Borders were being added where they were not needed, and making the width calculations mess up.