### PR TITLE
Feature: Headlline background mixin adjustments

### DIFF
--- a/src/components/headline/_headline-mixins.scss
+++ b/src/components/headline/_headline-mixins.scss
@@ -54,9 +54,15 @@
   -webkit-box-decoration-break: clone;
   color: $secondary;
   text-shadow: none;
-  [class*="bg--gold"] & {
+  [class*="bg--gold"] &,
+  .bg-pattern--brain-black .bg-pattern--brain-reversed & {
     background: $secondary;
     color: #fff;
+  }
+  [class*="bg--gold"] [class*="bg--black"] &,
+  [class*="bg--gold"] [class*="bg-pattern--brain-black"] & {
+    background: $primary;
+    color: $secondary;
   }
 }
 
@@ -71,6 +77,11 @@
     background: $secondary;
     color: #fff;
     font-weight: 400;
+  }
+  [class*="bg--gold"] [class*="bg--black"] &,
+  [class*="bg--gold"] [class*="bg-pattern--brain-black"] & {
+    background: $primary;
+    color: $secondary;
   }
 }
 
@@ -93,7 +104,10 @@
   }
 
   .bg-pattern--brain-black &,
-  [class*="bg--black"] & {
+  [class*="bg--black"] &,
+  [class*="bg--gold"] [class*="bg--black"] &,
+  [class*="bg--gold"] [class*="bg-pattern--brain-black"] &,
+  .bg-pattern--brain-reversed .bg-pattern--brain-black & {
     box-shadow: inset 0 -0.175em $secondary, inset 0 -0.25em $primary;
   }
 


### PR DESCRIPTION
This pr is to fix headline styles nested within containers with another background style. 

Example below:

<img width="1580" alt="Screen Shot 2021-04-07 at 10 45 47 AM" src="https://user-images.githubusercontent.com/1036433/113937122-4f015580-97be-11eb-8183-47bd23a7f8de.png">
