### PR TITLE
Feature: Default table styles

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -65,7 +65,7 @@ jobs:
 
       # Debugging messages.
       - run: echo "${{ github.ref }}"
-      - run: echo "${{ toJson(github) }}"
+#      - run: echo "${{ toJson(github) }}"
 #      - run: echo "${{ env.MAIN_BRANCH }}"
 #      - run: echo "Main check - ${{ github.ref == format('refs/heads/{0}', env.MAIN_BRANCH) }}"
 #      - run: echo "Branch check - ${{ contains(github.ref, 'refs/heads/') && github.ref != format('refs/heads/{0}', env.MAIN_BRANCH) }}"

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,8 +4,8 @@ name: Update documentation in GitHub Pages
 on:
   delete:
   push:
-    branches:
-      - '*'
+    branches-ignore:
+      - "dependabot/**"
     tags:
       - '*'
       # @todo Change this to only reference tags starting with v.

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -65,7 +65,7 @@ jobs:
 
       # Debugging messages.
       - run: echo "${{ github.ref }}"
-      - run: echo "${{ toJson(github.event) }}"
+      - run: echo "${{ toJson(github) }}"
 #      - run: echo "${{ env.MAIN_BRANCH }}"
 #      - run: echo "Main check - ${{ github.ref == format('refs/heads/{0}', env.MAIN_BRANCH) }}"
 #      - run: echo "Branch check - ${{ contains(github.ref, 'refs/heads/') && github.ref != format('refs/heads/{0}', env.MAIN_BRANCH) }}"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The node-gyp package requires a C compiler. If you notice node-gyp errors after 
 ### Install dependencies
 First, install NPM dependencies:
 ```
-npm install
+npm ci
 ```
 
 ### Start the local server.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To see the full options for the command, run `npm version --help`.
 8. Enter the "Tag version" using the version _with_ the `v` at the front (e.g. "v3.1.1").
 9. Enter the "Release title" using the version _without_ the `v` at the front (e.g. "3.1.1").
 10. Paste in the compare link into the description area: `https://github.com/uiowa/uids/compare/v3.1.0...v3.1.1`
-11. Click "Publish release" button.
+11. Click the "Publish release" button.
 12. Profit!
 
 ### Components

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uiowa/uids",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "The UIowa Design System is specific to the University of Iowa.",
   "keywords": [
     "uiowa",

--- a/src/components/tables/table-responsive--UNUSED/table-responsive.js
+++ b/src/components/tables/table-responsive--UNUSED/table-responsive.js
@@ -68,9 +68,9 @@ function generateResponsiveTables() {
           header_HTML = header_HTML +
             '<div class="table__sticky-heading" data-scroller-heading="t-' + i + '-h-' + j + '">\
               <div class="text-positioner">' +
-                thead.innerHTML +
-              '</div>\
-            </div>'
+            thead.innerHTML +
+            '</div>\
+          </div>'
           ;
         }
       };
@@ -100,6 +100,12 @@ function generateResponsiveTables() {
             </div>\
           </div>';
       }
+
+
+      // Wrap the table in a responsive table div, and make sure aria knows what caption labels it, if any.
+      // This should be done last as to not mess up any scoping of previous functions.
+      // @todo Remove this after striping is the default.
+      let classes = (table.classList.contains('table--is-striped') || table.classList.contains('is-striped')) ? 'table__responsive-container--is-striped' : '';
 
       // If the table has the .table--gray-borders class, add .table__responsive-container--gray-borders to the responsive table container as well.
       if (table.classList.contains('table--gray-borders')) {

--- a/src/components/tables/table-responsive--UNUSED/table-responsive.scss
+++ b/src/components/tables/table-responsive--UNUSED/table-responsive.scss
@@ -1,0 +1,143 @@
+@import '../../../assets/scss/variables';
+@import '../../../assets/scss/utilities';
+
+.table {
+  &__responsive-container {
+    border: 1px solid #eee;
+    width: 100%;
+    position: relative;
+
+    table {
+      width: 100%;
+
+      caption {
+        @include element-invisible();
+      }
+    }
+
+    &--width-default {
+      width: unset;
+      display: inline-block;
+
+      table.table--width-default {
+        width: unset;
+      }
+    }
+
+    &.table__row-headers--true {
+
+      // A sticky heading is a heading in the JS generated table__responsive-header container.
+      .table__sticky-heading:first-child {
+        left: 0;
+      }
+
+      &.table--left-sticky-minwidth .table__sticky-heading:first-child {
+        position: sticky;
+      }
+    }
+
+    &.table--is-sticky-top {
+      .table__responsive-header {
+        transition: filter 0.3s ease-in-out;
+        filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.2));
+      }
+    }
+
+    &.table__responsive-container--gray-borders {
+      border: unset;
+
+      .table__visual-caption {
+        border: #7c7c7c 1px solid;
+        border-bottom: none;
+      }
+
+      table > tbody > tr:first-child {
+        th, td {
+          border-top: none;
+        }
+      }
+
+      .table__responsive-header .table__sticky-heading {
+        border-left: #7c7c7c 1px solid;
+        border-bottom: #ddd 1px solid;
+        border-top: #ddd 1px solid;
+
+        &:first-child {
+          border-left: 1px solid #ddd;
+        }
+      }
+    }
+
+    &.table--is-sticky-left.table--left-sticky-minwidth {
+      tbody th {
+        filter: drop-shadow(0px 4px 2px rgba(0, 0, 0, 0.2));
+      }
+
+      .table__sticky-heading:first-child {
+        border-right: 1px solid #ccc;
+        filter: drop-shadow(0px 4px 2px rgba(0, 0, 0, 0.2));
+      }
+    }
+
+    .table__responsive-header__sticky-heading:first-child {
+      border-right: none;
+      transition: border-right 0.3s ease-in-out;
+    }
+
+    &.table--left-sticky-minwidth table tbody th {
+      position: sticky;
+    }
+
+    .text-formatted & div {
+      line-height: inherit;
+      font-size: $base-font-size;
+      margin-bottom: 0;
+    }
+  }
+
+  &__visual-caption {
+  }
+
+  &__responsive-header {
+    position: sticky;
+    z-index: 1;
+    top: 0;
+
+    &__scroller {
+      white-space: nowrap;
+      overflow-x: hidden;
+    }
+  }
+
+  &__sticky-heading {
+    background: $primary;
+    border: none;
+    color: $secondary;
+    display: inline-block;
+    font-size: $base-font-size;
+    padding: $md;
+    text-align: left;
+    text-transform: uppercase;
+
+    .text-positioner {
+      white-space: break-spaces;
+      display: flex;
+      align-items: flex-end;
+      width: 100%;
+      height: 100%;
+      font-weight: bold;
+    }
+  }
+
+  &__container {
+    overflow-x: auto;
+  }
+
+  &.table--static {
+
+    tbody th,
+    thead th {
+      position: static;
+    }
+  }
+}

--- a/src/components/tables/tables--responsive.twig
+++ b/src/components/tables/tables--responsive.twig
@@ -1,0 +1,234 @@
+<div class="container">
+  <div class="table-responsive">
+    <table class="table--hover-highlight table--gray-borders">
+      <thead>
+      <tr>
+        <th>Person</th>
+        <th>Number</th>
+        <th>Third Column</th>
+        <th>Fourth Column</th>
+        <th>Fifth Column</th>
+        <th>Sixth Column</th>
+        <th>Seventhth Column</th>
+        <th>Eighth Column</th>
+        <th>Ninth Column</th>
+        <th>Tenth Column</th>
+        <th>Eleventh Column</th>
+        <th>Twelfth Column</th>
+        <th>Thirteenth Column</th>
+        <th>Fourteenth Column</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <th>Someone Lastname</th>
+        <td>900</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>
+          <a href="#">Person Name</a>
+        </th>
+        <td>1200</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>Another Person</th>
+        <td>1500</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>some other person</th>
+        <td>2800</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>Someone and a Lastname</th>
+        <td>500</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>
+          <a href="#">Linked Name</a>
+        </th>
+        <td>1720</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>Another random person</th>
+        <td>1200</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>Some other Person</th>
+        <td>2200</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>Firstname and something</th>
+        <td>920</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>
+          <a href="#">Linked Other Name</a>
+        </th>
+        <td>1208</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>Another Person Randomly selected</th>
+        <td>1550</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>Last One</th>
+        <td>2830</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+<style>
+@media screen and (min-width: 40em) {
+  @media (min-width: 84.375em) {
+    .container {
+      max-width:81.875em;
+      margin: 0 auto
+    }
+  }
+}
+</style>

--- a/src/components/tables/tables.config.yml
+++ b/src/components/tables/tables.config.yml
@@ -2,5 +2,11 @@ title: Tables
 status: wip
 order: 10
 collated: false
+meta:
+  dependencies:
+    stylesheets:
+      - /components/typography/headings/headings.css
+      - /components/typography/lists/lists.css
+      - /components/typography/paragraph/paragraph.css
 context:
     test: test

--- a/src/components/tables/tables.config.yml
+++ b/src/components/tables/tables.config.yml
@@ -10,3 +10,9 @@ meta:
       - /components/typography/paragraph/paragraph.css
 context:
     test: test
+variants:
+    - name: default
+      label:
+    - name: responsive
+      label: Responsive
+      hidden: true

--- a/src/components/tables/tables.js
+++ b/src/components/tables/tables.js
@@ -104,6 +104,7 @@ function generateResponsiveTables() {
 
             // Wrap the table in a responsive table div, and make sure aria knows what caption labels it, if any.
             // This should be done last as to not mess up any scoping of previous functions.
+          // @todo Remove this after striping is the default.
             let classes = (table.classList.contains('table--is-striped') || table.classList.contains('is-striped')) ? 'table__responsive-container--is-striped' : '';
 
             // If the table has the .table--gray-borders class, add .table__responsive-container--gray-borders to the responsive table container as well.

--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -55,6 +55,9 @@ table {
     background-color: $primary;
     border: none;
     text-transform: uppercase;
+    a {
+      color: $secondary;
+    }
   }
 
   tbody th {

--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -32,7 +32,6 @@ table {
   th {
     padding: $md;
     font-size: $base-font-size;
-    min-width: 100px;
   }
 
   th {

--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -13,7 +13,6 @@ table[border] {
 
 table {
   background-color: $white;
-  border: 1px solid #eee;
   border-collapse: collapse;
   border-spacing: 0;
   color: $secondary;
@@ -99,8 +98,6 @@ table {
 }
 
 table.table--gray-borders {
-  border: #ddd 1px solid;
-
   & > tr,
   & > tbody > tr,
   & > tfoot > tr {
@@ -137,147 +134,6 @@ table.table--gray-borders {
   & > tbody > tr:first-child {
     th, td {
       border-top: none;
-    }
-  }
-}
-
-.table {
-  &__responsive-container {
-    border: 1px solid #eee;
-    width: 100%;
-    position: relative;
-
-    table {
-      width: 100%;
-
-      caption {
-        @include element-invisible();
-      }
-    }
-
-    &--width-default {
-      width: unset;
-      display: inline-block;
-
-      table.table--width-default {
-        width: unset;
-      }
-    }
-
-    &.table__row-headers--true {
-
-      // A sticky heading is a heading in the JS generated table__responsive-header container.
-      .table__sticky-heading:first-child {
-        left: 0;
-      }
-
-      &.table--left-sticky-minwidth .table__sticky-heading:first-child {
-        position: sticky;
-      }
-    }
-
-    &.table--is-sticky-top {
-      .table__responsive-header {
-        transition: filter 0.3s ease-in-out;
-        filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.2));
-      }
-    }
-
-    &.table__responsive-container--gray-borders {
-      border: unset;
-
-      .table__visual-caption {
-        border: #7c7c7c 1px solid;
-        border-bottom: none;
-      }
-
-      table > tbody > tr:first-child {
-        th, td {
-          border-top: none;
-        }
-      }
-
-      .table__responsive-header .table__sticky-heading {
-        border-left: #7c7c7c 1px solid;
-        border-bottom: #ddd 1px solid;
-        border-top: #ddd 1px solid;
-
-        &:first-child {
-          border-left: 1px solid #ddd;
-        }
-      }
-    }
-
-    &.table--is-sticky-left.table--left-sticky-minwidth {
-      tbody th {
-        filter: drop-shadow(0px 4px 2px rgba(0, 0, 0, 0.2));
-      }
-
-      .table__sticky-heading:first-child {
-        border-right: 1px solid #ccc;
-        filter: drop-shadow(0px 4px 2px rgba(0, 0, 0, 0.2));
-      }
-    }
-
-    .table__responsive-header__sticky-heading:first-child {
-      border-right: none;
-      transition: border-right 0.3s ease-in-out;
-    }
-
-    &.table--left-sticky-minwidth table tbody th {
-      position: sticky;
-    }
-
-    .text-formatted & div {
-      line-height: inherit;
-      font-size: $base-font-size;
-      margin-bottom: 0;
-    }
-  }
-
-  &__visual-caption {
-  }
-
-  &__responsive-header {
-    position: sticky;
-    z-index: 1;
-    top: 0;
-
-    &__scroller {
-      white-space: nowrap;
-      overflow-x: hidden;
-    }
-  }
-
-  &__sticky-heading {
-    background: $primary;
-    border: none;
-    color: $secondary;
-    display: inline-block;
-    font-size: $base-font-size;
-    padding: $md;
-    text-align: left;
-    text-transform: uppercase;
-
-    .text-positioner {
-      white-space: break-spaces;
-      display: flex;
-      align-items: flex-end;
-      width: 100%;
-      height: 100%;
-      font-weight: bold;
-    }
-  }
-
-  &__container {
-    overflow-x: auto;
-  }
-
-  &.table--static {
-
-    tbody th,
-    thead th {
-      position: static;
     }
   }
 }

--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -107,6 +107,10 @@ table {
   }
 }
 
+.table-responsive {
+  overflow-x: auto;
+}
+
 table.table--gray-borders {
   & > tr,
   & > tbody > tr,

--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -140,6 +140,14 @@ table.table--gray-borders {
     width: 100%;
     position: relative;
 
+    table {
+      width: 100%;
+
+      caption {
+        @include element-invisible();
+      }
+    }
+
     &--width-default {
       width: unset;
       display: inline-block;
@@ -161,45 +169,16 @@ table.table--gray-borders {
       }
     }
 
-    &.table__responsive-container--is-striped {
-
-      // @todo How does this get applied to the default case now?
-      &.table__responsive-container--gray-borders {
-        border: unset;
-      }
-
-      &.table--is-sticky-left.table--left-sticky-minwidth {
-        // DO NOT USE THE .is-striped CLASS. it is a legacy class, and you should be using .table--is-striped.
-        table.is-striped,
-        table.table--is-striped{
-          tbody th {
-            filter: drop-shadow(0px 4px 2px rgba(0, 0, 0, 0.2));
-          }
-        }
-
-        .table__sticky-heading:first-child {
-          filter: drop-shadow(0px 4px 2px rgba(0, 0, 0, 0.2));
-        }
-      }
-
-      &.table--is-sticky-top {
-        .table__responsive-header {
-          transition: filter 0.3s ease-in-out;
-          filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.2));
-        }
-      }
-
-      &.table__responsive-container--gray-borders .table__responsive-header .table__sticky-heading {
-        border-left: #7c7c7c 1px solid;
-        border-bottom: #ddd 1px solid;
-
-        &:first-child {
-          border-left: 1px solid #ddd;
-        }
+    &.table--is-sticky-top {
+      .table__responsive-header {
+        transition: filter 0.3s ease-in-out;
+        filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.2));
       }
     }
 
     &.table__responsive-container--gray-borders {
+      border: unset;
+
       .table__visual-caption {
         border: #7c7c7c 1px solid;
         border-bottom: none;
@@ -212,9 +191,9 @@ table.table--gray-borders {
       }
 
       .table__responsive-header .table__sticky-heading {
-        border-left: #ddd 1px solid;
-        border-top: #ddd 1px solid;
+        border-left: #7c7c7c 1px solid;
         border-bottom: #ddd 1px solid;
+        border-top: #ddd 1px solid;
 
         &:first-child {
           border-left: 1px solid #ddd;
@@ -222,25 +201,20 @@ table.table--gray-borders {
       }
     }
 
-    table {
-      width: 100%;
+    &.table--is-sticky-left.table--left-sticky-minwidth {
+      tbody th {
+        filter: drop-shadow(0px 4px 2px rgba(0, 0, 0, 0.2));
+      }
 
-      caption {
-        @include element-invisible();
+      .table__sticky-heading:first-child {
+        border-right: 1px solid #ccc;
+        filter: drop-shadow(0px 4px 2px rgba(0, 0, 0, 0.2));
       }
     }
 
-    &.table--is-sticky-left.table--left-sticky-minwidth .table__sticky-heading:first-child {
-      border-right: 1px solid #ccc;
-    }
-
     .table__responsive-header__sticky-heading:first-child {
-      border-right: 1px solid #fff;
-      transition: border-right 0.3s ease-in-out;
-    }
-
-    &.table--is-sticky-left.table__responsive-container--is-striped.table--left-sticky-minwidth .table__sticky-heading:first-child {
       border-right: none;
+      transition: border-right 0.3s ease-in-out;
     }
 
     &.table--left-sticky-minwidth table tbody th {

--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -27,6 +27,16 @@ table {
     display: table;
   }
 
+  p, ul, ol {
+    font-size: $base-font-size;
+  }
+
+  ul, ol {
+    p {
+      margin-bottom: 0;
+    }
+  }
+
   td,
   th {
     padding: $md;

--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -17,13 +17,22 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
   color: $secondary;
+  display: inline-block;
   font-size: $content-font-size;
+  max-width: 100%;
+  overflow-x: auto;
+  // @todo Add white-space: nowrap?
   width: 100%;
+
+  @include breakpoint(sm) {
+    display: table;
+  }
 
   td,
   th {
     padding: $md;
     font-size: $base-font-size;
+    min-width: 100px;
   }
 
   th {
@@ -64,7 +73,7 @@ table {
     }
   }
 
-  &:not(.table__responsive) caption {
+  caption {
     width: 100%;
     padding: 1.05rem;
     text-align: center;
@@ -228,14 +237,6 @@ table.table--gray-borders {
   }
 
   &__visual-caption {
-    width: 100%;
-    padding: 1.05rem;
-    text-align: center;
-    font-size: 1rem;
-    color: #fff;
-    text-transform: uppercase;
-    background-color: #333;
-    font-weight: bold;
   }
 
   &__responsive-header {

--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -12,6 +12,7 @@ table[border] {
 }
 
 table {
+  border: 1px solid #eee;
   width: 100%;
   font-size: $content-font-size;
   border-spacing: 0;
@@ -35,16 +36,22 @@ table {
   }
 
   thead th {
-    background-color: #fff;
-    border-bottom: 1px solid #cccccc;
+    background-color: $primary;
+    border: none;
+    text-transform: uppercase;
   }
 
   tbody th {
     background-color: #fff;
-    border-right: 1px solid #cccccc;
+    border: none;
     position: static;
     left: 0;
     padding-left: $md;
+  }
+
+  tbody tr:not(.is-selected):nth-child(even),
+  tbody tr:not(.is-selected):nth-child(even) th {
+    background-color: $light;
   }
 
   &.table--hover-highlight tbody tr:not(.is-selected),
@@ -79,27 +86,6 @@ table {
     color: $secondary;
   }
 
-  // DO NOT USE THE .is-striped CLASS. it is a legacy class, and you should be using .table--is-striped.
-  &.is-striped,
-  &.table--is-striped{
-    border: 1px solid #eee;
-
-    thead th {
-      background: $primary;
-      text-transform: uppercase;
-      border: none;
-    }
-
-    tbody th {
-      border: none;
-    }
-
-    tbody tr:not(.is-selected):nth-child(even),
-    tbody tr:not(.is-selected):nth-child(even) th {
-      background-color: $light;
-    }
-  }
-
   &.table--width-default {
     width: unset;
   }
@@ -110,12 +96,34 @@ table.table--gray-borders {
 
   & > tr,
   & > tbody > tr,
-  & > tfoot > tr,
+  & > tfoot > tr {
+    & > td,
+    & > th {
+      border: #ddd 1px solid;
+    }
+  }
+
   & > thead > tr,
   & > caption {
     & > td,
     & > th {
-      border: #ddd 1px solid;
+      border: #7c7c7c 1px solid;
+    }
+  }
+
+  & > thead > tr {
+    & > td,
+    & > th {
+      border-bottom: #ddd 1px solid;
+      border-top: #ddd 1px solid;
+
+      &:first-child {
+        border-left: #ddd 1px solid;
+      }
+
+      &:last-child {
+        border-right: #ddd 1px solid;
+      }
     }
   }
 
@@ -124,38 +132,11 @@ table.table--gray-borders {
       border-top: none;
     }
   }
-
-  // DO NOT USE THE .is-striped CLASS. it is a legacy class, and you should be using .table--is-striped.
-  &.is-striped,
-  &.table--is-striped {
-    & > thead > tr,
-    & > caption {
-      & > td,
-      & > th {
-        border: #7c7c7c 1px solid;
-      }
-    }
-
-    & > thead > tr {
-      & > td,
-      & > th {
-        border-bottom: #ddd 1px solid;
-        border-top: #ddd 1px solid;
-
-        &:first-child {
-          border-left: #ddd 1px solid;
-        }
-
-        &:last-child {
-          border-right: #ddd 1px solid;
-        }
-      }
-    }
-  }
 }
 
 .table {
   &__responsive-container {
+    border: 1px solid #eee;
     width: 100%;
     position: relative;
 
@@ -181,8 +162,8 @@ table.table--gray-borders {
     }
 
     &.table__responsive-container--is-striped {
-      border: 1px solid #eee;
 
+      // @todo How does this get applied to the default case now?
       &.table__responsive-container--gray-borders {
         border: unset;
       }
@@ -195,7 +176,6 @@ table.table--gray-borders {
             filter: drop-shadow(0px 4px 2px rgba(0, 0, 0, 0.2));
           }
         }
-
 
         .table__sticky-heading:first-child {
           filter: drop-shadow(0px 4px 2px rgba(0, 0, 0, 0.2));
@@ -244,12 +224,6 @@ table.table--gray-borders {
 
     table {
       width: 100%;
-
-      // DO NOT USE THE .is-striped CLASS. it is a legacy class, and you should be using .table--is-striped.
-      &.is-striped,
-      &.table--is-striped{
-        border: none;
-      }
 
       caption {
         @include element-invisible();
@@ -300,25 +274,18 @@ table.table--gray-borders {
       white-space: nowrap;
       overflow-x: hidden;
     }
-
-    .table__responsive-container--is-striped & {
-      .table__sticky-heading {
-        background: $primary;
-        text-transform: uppercase;
-        border: none;
-      }
-    }
   }
 
   &__sticky-heading {
-    display: inline-block;
-    padding: $md;
-    vertical-align: bottom;
-    font-size: $base-font-size;
+    background: $primary;
+    border: none;
     color: $secondary;
-    background-color: #fff;
-    border-bottom: 1px solid #cccccc;
+    display: inline-block;
+    font-size: $base-font-size;
+    padding: $md;
     text-align: left;
+    text-transform: uppercase;
+    vertical-align: bottom;
 
     .text-positioner {
       white-space: break-spaces;

--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -12,18 +12,17 @@ table[border] {
 }
 
 table {
-  border: 1px solid #eee;
-  width: 100%;
-  font-size: $content-font-size;
-  border-spacing: 0;
-  border-collapse: collapse;
-  color: $secondary;
   background-color: $white;
+  border: 1px solid #eee;
+  border-collapse: collapse;
+  border-spacing: 0;
+  color: $secondary;
+  font-size: $content-font-size;
+  width: 100%;
 
   td,
   th {
     padding: $md;
-    vertical-align: bottom;
     font-size: $base-font-size;
   }
 
@@ -259,7 +258,6 @@ table.table--gray-borders {
     padding: $md;
     text-align: left;
     text-transform: uppercase;
-    vertical-align: bottom;
 
     .text-positioner {
       white-space: break-spaces;

--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -109,6 +109,10 @@ table {
 
 .table-responsive {
   overflow-x: auto;
+
+  table {
+    display: table;
+  }
 }
 
 table.table--gray-borders {

--- a/src/components/tables/tables.twig
+++ b/src/components/tables/tables.twig
@@ -1,199 +1,202 @@
-<table>
-  <caption>This is a default table.</caption>
-  <thead>
-  <tr>
-    <th>Person</th>
-    <th>Number</th>
-    <th>Third Column</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <th>Someone Lastname</th>
-    <td>900</td>
-    <td>Nullam quis risus eget urna mollis ornare vel eu leo.</td>
-  </tr>
-  <tr>
-    <th>
-      <a href="#">Person Name</a>
-    </th>
-    <td>1200</td>
-    <td>Vestibulum id ligula porta felis euismod semper. Donec ullamcorper
-      nulla non metus auctor fringilla.</td>
-  </tr>
-  <tr>
-    <th>Another Person</th>
-    <td>1500</td>
-    <td>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor
-      auctor. Nullam id dolor id nibh ultricies vehicula ut id elit.</td>
-  </tr>
-  <tr>
-    <th>Last One</th>
-    <td>2800</td>
-    <td>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Cras
-      mattis consectetur purus sit amet fermentum.</td>
-  </tr>
-  </tbody>
-</table>
-<br>
-<table class="table--gray-borders table--width-default">
-  <caption>Tables can have captions now.</caption>
-  <thead>
-  <tr>
-    <th>Person</th>
-    <th>Number</th>
-    <th>Third Column</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <th>Someone Lastname</th>
-    <td>900</td>
-    <td>Nullam quis risus eget urna mollis ornare vel eu leo.</td>
-  </tr>
-  <tr>
-    <th>
-      <a href="#">Person Name</a>
-    </th>
-    <td>1200</td>
-    <td>Vestibulum id ligula porta felis euismod semper. Donec ullamcorper
-      nulla non metus auctor fringilla.</td>
-  </tr>
-  <tr>
-    <th>Another Person</th>
-    <td>1500</td>
-    <td>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor
-      auctor. Nullam id dolor id nibh ultricies vehicula ut id elit.</td>
-  </tr>
-  <tr>
-    <th>Last One</th>
-    <td>2800</td>
-    <td>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Cras
-      mattis consectetur purus sit amet fermentum.</td>
-  </tr>
-  </tbody>
-</table>
+<div class="container">
+  <table>
+    <caption>This is a default table.</caption>
+    <thead>
+    <tr>
+      <th>Person</th>
+      <th>Number</th>
+      <th>Third Column</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <th>Someone Lastname</th>
+      <td>900</td>
+      <td>Nullam quis risus eget urna mollis ornare vel eu leo.</td>
+    </tr>
+    <tr>
+      <th>
+        <a href="#">Person Name</a>
+      </th>
+      <td>1200</td>
+      <td>Vestibulum id ligula porta felis euismod semper. Donec ullamcorper
+        nulla non metus auctor fringilla.</td>
+    </tr>
+    <tr>
+      <th>Another Person</th>
+      <td>1500</td>
+      <td>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor
+        auctor. Nullam id dolor id nibh ultricies vehicula ut id elit.</td>
+    </tr>
+    <tr>
+      <th>Last One</th>
+      <td>2800</td>
+      <td>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Cras
+        mattis consectetur purus sit amet fermentum.</td>
+    </tr>
+    </tbody>
+  </table>
 
-<br/><br/>
+  <br/><br/>
 
-<table class="table--gray-borders table--static">
-  <caption class="element-invisible">Tables can have captions now.</caption>
-  <thead>
-  <tr>
-    <th>Person</th>
-    <th>Number</th>
-    <th>Third Column</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <th>Someone Lastname</th>
-    <td>900</td>
-    <td>Nullam quis risus eget urna mollis ornare vel eu leo.</td>
-  </tr>
-  <tr>
-    <th>
-      <a href="#">Person Name</a>
-    </th>
-    <td>1200</td>
-    <td>Vestibulum id ligula porta felis euismod semper. Donec ullamcorper
-      nulla non metus auctor fringilla.</td>
-  </tr>
-  <tr>
-    <th>Another Person</th>
-    <td>1500</td>
-    <td>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor
-      auctor. Nullam id dolor id nibh ultricies vehicula ut id elit.</td>
-  </tr>
-  <tr>
-    <th>Last One</th>
-    <td>2800</td>
-    <td>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Cras
-      mattis consectetur purus sit amet fermentum.</td>
-  </tr>
-  </tbody>
-</table>
+  <table class="table--gray-borders table--width-default">
+    <caption>Tables can have captions now.</caption>
+    <thead>
+    <tr>
+      <th>Person</th>
+      <th>Number</th>
+      <th>Third Column</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <th>Someone Lastname</th>
+      <td>900</td>
+      <td>Nullam quis risus eget urna mollis ornare vel eu leo.</td>
+    </tr>
+    <tr>
+      <th>
+        <a href="#">Person Name</a>
+      </th>
+      <td>1200</td>
+      <td>Vestibulum id ligula porta felis euismod semper. Donec ullamcorper
+        nulla non metus auctor fringilla.</td>
+    </tr>
+    <tr>
+      <th>Another Person</th>
+      <td>1500</td>
+      <td>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor
+        auctor. Nullam id dolor id nibh ultricies vehicula ut id elit.</td>
+    </tr>
+    <tr>
+      <th>Last One</th>
+      <td>2800</td>
+      <td>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Cras
+        mattis consectetur purus sit amet fermentum.</td>
+    </tr>
+    </tbody>
+  </table>
 
-<br/><br/>
+  <br/><br/>
 
-<table class="table--static table--width-default" summary="Undergraduate Cost of Attendence - Living on Campus Example Table">
-  <caption><strong>Living On Campus - Example Table</strong></caption>
-	<thead>
+  <table class="table--gray-borders">
+    <caption class="element-invisible">Tables can have captions now.</caption>
+    <thead>
+    <tr>
+      <th>Person</th>
+      <th>Number</th>
+      <th>Third Column</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <th>Someone Lastname</th>
+      <td>900</td>
+      <td>Nullam quis risus eget urna mollis ornare vel eu leo.</td>
+    </tr>
+    <tr>
+      <th>
+        <a href="#">Person Name</a>
+      </th>
+      <td>1200</td>
+      <td>Vestibulum id ligula porta felis euismod semper. Donec ullamcorper
+        nulla non metus auctor fringilla.</td>
+    </tr>
+    <tr>
+      <th>Another Person</th>
+      <td>1500</td>
+      <td>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor
+        auctor. Nullam id dolor id nibh ultricies vehicula ut id elit.</td>
+    </tr>
+    <tr>
+      <th>Last One</th>
+      <td>2800</td>
+      <td>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Cras
+        mattis consectetur purus sit amet fermentum.</td>
+    </tr>
+    </tbody>
+  </table>
+
+  <br/><br/>
+
+  <table class="table--width-default" summary="Undergraduate Cost of Attendence - Living on Campus Example Table">
+    <caption><strong>Living On Campus - Example Table</strong></caption>
+    <thead>
     <tr><th scope="row">&nbsp;</th>
-			<th scope="col">Resident</th>
-			<th scope="col">Nonresident</th>
-		</tr>
-  </thead>
-  <tbody>
+      <th scope="col">Resident</th>
+      <th scope="col">Nonresident</th>
+    </tr>
+    </thead>
+    <tbody>
     <tr><th colspan="3" scope="row">Estimated Charges</th>
-		</tr><tr><th scope="row">Tuition &amp; Fees</th>
-			<td>$0,000</td>
-			<td>$00,000</td>
-		</tr><tr><th scope="row">Housing &amp; Meals</th>
-			<td>$00,000</td>
-			<td>$00,000</td>
-		</tr><tr><th scope="row">Subtotal</th>
-			<td><strong>$00,000</strong></td>
-			<td><strong>$00,000</strong></td>
-		</tr><tr><th colspan="3" scope="row">Other Estimated Expenses</th>
-		</tr><tr><th scope="row">Books &amp; Supplies</th>
-			<td>$000</td>
-			<td>$000</td>
-		</tr><tr><th scope="row">Personal</th>
-			<td>$0,000</td>
-			<td>$0,000</td>
-		</tr><tr><th scope="row">Transportation</th>
-			<td>$000</td>
-			<td>$000</td>
-		</tr><tr><th scope="row"><strong>Total</strong></th>
-			<td><strong>$00,000</strong></td>
-			<td><strong>$00,000</strong></td>
-		</tr>
-  </tbody>
-</table>
+    </tr><tr><th scope="row">Tuition &amp; Fees</th>
+      <td>$0,000</td>
+      <td>$00,000</td>
+    </tr><tr><th scope="row">Housing &amp; Meals</th>
+      <td>$00,000</td>
+      <td>$00,000</td>
+    </tr><tr><th scope="row">Subtotal</th>
+      <td><strong>$00,000</strong></td>
+      <td><strong>$00,000</strong></td>
+    </tr><tr><th colspan="3" scope="row">Other Estimated Expenses</th>
+    </tr><tr><th scope="row">Books &amp; Supplies</th>
+      <td>$000</td>
+      <td>$000</td>
+    </tr><tr><th scope="row">Personal</th>
+      <td>$0,000</td>
+      <td>$0,000</td>
+    </tr><tr><th scope="row">Transportation</th>
+      <td>$000</td>
+      <td>$000</td>
+    </tr><tr><th scope="row"><strong>Total</strong></th>
+      <td><strong>$00,000</strong></td>
+      <td><strong>$00,000</strong></td>
+    </tr>
+    </tbody>
+  </table>
 
-<br/><br/>
+  <br/><br/>
 
-<table class="table--static table--gray-borders" summary="Undergraduate Cost of Attendence - Living on Campus Example Table">
-  <thead>
-  <tr><th scope="row">&nbsp;</th>
-    <th scope="col">Resident</th>
-    <th scope="col">Nonresident</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr><th colspan="3" scope="row">Estimated Charges</th>
-  </tr><tr><th scope="row">Tuition &amp; Fees</th>
-    <td>$0,000</td>
-    <td>$00,000</td>
-  </tr><tr><th scope="row">Housing &amp; Meals</th>
-    <td>$00,000</td>
-    <td>$00,000</td>
-  </tr><tr><th scope="row">Subtotal</th>
-    <td><strong>$00,000</strong></td>
-    <td><strong>$00,000</strong></td>
-  </tr><tr><th colspan="3" scope="row">Other Estimated Expenses</th>
-  </tr><tr><th scope="row">Books &amp; Supplies</th>
-    <td>$000</td>
-    <td>$000</td>
-  </tr><tr><th scope="row">Personal</th>
-    <td>$0,000</td>
-    <td>$0,000</td>
-  </tr><tr><th scope="row">Transportation</th>
-    <td>$000</td>
-    <td>$000</td>
-  </tr><tr><th scope="row"><strong>Total</strong></th>
-    <td><strong>$00,000</strong></td>
-    <td><strong>$00,000</strong></td>
-  </tr>
-  </tbody>
-</table>
+  <table class="table--gray-borders" summary="Undergraduate Cost of Attendence - Living on Campus Example Table">
+    <thead>
+    <tr><th scope="row">&nbsp;</th>
+      <th scope="col">Resident</th>
+      <th scope="col">Nonresident</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr><th colspan="3" scope="row">Estimated Charges</th>
+    </tr><tr><th scope="row">Tuition &amp; Fees</th>
+      <td>$0,000</td>
+      <td>$00,000</td>
+    </tr><tr><th scope="row">Housing &amp; Meals</th>
+      <td>$00,000</td>
+      <td>$00,000</td>
+    </tr><tr><th scope="row">Subtotal</th>
+      <td><strong>$00,000</strong></td>
+      <td><strong>$00,000</strong></td>
+    </tr><tr><th colspan="3" scope="row">Other Estimated Expenses</th>
+    </tr><tr><th scope="row">Books &amp; Supplies</th>
+      <td>$000</td>
+      <td>$000</td>
+    </tr><tr><th scope="row">Personal</th>
+      <td>$0,000</td>
+      <td>$0,000</td>
+    </tr><tr><th scope="row">Transportation</th>
+      <td>$000</td>
+      <td>$000</td>
+    </tr><tr><th scope="row"><strong>Total</strong></th>
+      <td><strong>$00,000</strong></td>
+      <td><strong>$00,000</strong></td>
+    </tr>
+    </tbody>
+  </table>
 
-<br/><br/>
+  <br/><br/>
 
-<table>
-  <caption class="element-invisible">Tables can have captions now.</caption>
-  <thead>
+  <table>
+    <caption class="element-invisible">Tables can have captions now.</caption>
+    <thead>
     <tr>
       <th>Person</th>
       <th>Number</th>
@@ -207,8 +210,8 @@
       <th>Tenth Column</th>
       <th>Eleventh Column</th>
     </tr>
-  </thead>
-  <tbody>
+    </thead>
+    <tbody>
     <tr>
       <th>Someone Lastname</th>
       <td>900</td>
@@ -371,394 +374,365 @@
       <td>1999</td>
       <td>1999</td>
     </tr>
-  </tbody>
-</table>
+    </tbody>
+  </table>
 
-<br/><br/>
+  <br/><br/>
 
-<table class="table--width-default table--gray-borders">
-  <caption class="element-invisible">This table was given a default width</caption>
-  <thead>
-  <tr>
-    <th>Person</th>
-    <th>Number</th>
-    <th>Third Column</th>
-    <th>Fourth Column</th>
-    <th>Fifth Column</th>
-    <th>Sixth Column</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <th>Someone Lastname</th>
-    <td>900</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>
-      <a href="#">Person Name</a>
-    </th>
-    <td>1200</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>Another Person</th>
-    <td>1500</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>some other person</th>
-    <td>2800</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>Someone and a Lastname</th>
-    <td>500</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>
-      <a href="#">Linked Name</a>
-    </th>
-    <td>1720</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>Another random person</th>
-    <td>1200</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>Some other Person</th>
-    <td>2200</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>Firstname and something</th>
-    <td>920</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>
-      <a href="#">Linked Other Name</a>
-    </th>
-    <td>1208</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>Another Person Randomly selected</th>
-    <td>1550</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>Last One</th>
-    <td>2830</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  </tbody>
-</table>
+  <table class="table--width-default table--gray-borders">
+    <caption class="element-invisible">This table was given a default width</caption>
+    <thead>
+    <tr>
+      <th>Person</th>
+      <th>Number</th>
+      <th>Third Column</th>
+      <th>Fourth Column</th>
+      <th>Fifth Column</th>
+      <th>Sixth Column</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <th>Someone Lastname</th>
+      <td>900</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>
+        <a href="#">Person Name</a>
+      </th>
+      <td>1200</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>Another Person</th>
+      <td>1500</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>some other person</th>
+      <td>2800</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>Someone and a Lastname</th>
+      <td>500</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>
+        <a href="#">Linked Name</a>
+      </th>
+      <td>1720</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>Another random person</th>
+      <td>1200</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>Some other Person</th>
+      <td>2200</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>Firstname and something</th>
+      <td>920</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>
+        <a href="#">Linked Other Name</a>
+      </th>
+      <td>1208</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>Another Person Randomly selected</th>
+      <td>1550</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>Last One</th>
+      <td>2830</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    </tbody>
+  </table>
 
-<br/><br/>
+  <br/><br/>
 
-<table class="table--hover-highlight table--gray-borders">
-  <thead>
-  <tr>
-    <th>Person</th>
-    <th>Number</th>
-    <th>Third Column</th>
-    <th>Fourth Column</th>
-    <th>Fifth Column</th>
-    <th>Sixth Column</th>
-    <th>Seventhth Column</th>
-    <th>Eighth Column</th>
-    <th>Ninth Column</th>
-    <th>Tenth Column</th>
-    <th>Eleventh Column</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <th>Someone Lastname</th>
-    <td>900</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>
-      <a href="#">Person Name</a>
-    </th>
-    <td>1200</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>Another Person</th>
-    <td>1500</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>some other person</th>
-    <td>2800</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>Someone and a Lastname</th>
-    <td>500</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>
-      <a href="#">Linked Name</a>
-    </th>
-    <td>1720</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>Another random person</th>
-    <td>1200</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>Some other Person</th>
-    <td>2200</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>Firstname and something</th>
-    <td>920</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>
-      <a href="#">Linked Other Name</a>
-    </th>
-    <td>1208</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>Another Person Randomly selected</th>
-    <td>1550</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  <tr>
-    <th>Last One</th>
-    <td>2830</td>
-    <td>9999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-    <td>1999</td>
-  </tr>
-  </tbody>
-</table>
-<br>
-<h2>Tables in a row</h2>
-<div class="row">
+  <table class="table--hover-highlight table--gray-borders">
+    <thead>
+    <tr>
+      <th>Person</th>
+      <th>Number</th>
+      <th>Third Column</th>
+      <th>Fourth Column</th>
+      <th>Fifth Column</th>
+      <th>Sixth Column</th>
+      <th>Seventhth Column</th>
+      <th>Eighth Column</th>
+      <th>Ninth Column</th>
+      <th>Tenth Column</th>
+      <th>Eleventh Column</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <th>Someone Lastname</th>
+      <td>900</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>
+        <a href="#">Person Name</a>
+      </th>
+      <td>1200</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>Another Person</th>
+      <td>1500</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>some other person</th>
+      <td>2800</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>Someone and a Lastname</th>
+      <td>500</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>
+        <a href="#">Linked Name</a>
+      </th>
+      <td>1720</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>Another random person</th>
+      <td>1200</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>Some other Person</th>
+      <td>2200</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>Firstname and something</th>
+      <td>920</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>
+        <a href="#">Linked Other Name</a>
+      </th>
+      <td>1208</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>Another Person Randomly selected</th>
+      <td>1550</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    <tr>
+      <th>Last One</th>
+      <td>2830</td>
+      <td>9999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+      <td>1999</td>
+    </tr>
+    </tbody>
+  </table>
+
+  <br/><br/>
+
+  <table>
+    <thead>
+    <tr>
+      <th>Year</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>2001</td>
+    </tr>
+    <tr>
+      <td>2002</td>
+    </tr>
+    <tr>
+      <td>2003</td>
+    </tr>
+    <tr>
+      <td>2004</td>
+    </tr>
+    </tbody>
+  </table>
+
+  <br/><br/>
+
+  <table class="table--gray-borders">
+    <thead>
+    <tr>
+      <th>Year</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>2001</td>
+    </tr>
+    <tr>
+      <td>2002</td>
+    </tr>
+    <tr>
+      <td>2003</td>
+    </tr>
+    <tr>
+      <td>2004</td>
+    </tr>
+    </tbody>
+  </table>
+
+  <br/><br/>
+
   <div class="column">
-    <table>
-      <caption>This is a default table.</caption>
-      <thead>
-      <tr>
-        <th>Person</th>
-        <th>Number</th>
-        <th>Third Column</th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr>
-        <th>Someone Lastname</th>
-        <td>900</td>
-        <td>Nullam quis risus eget urna mollis ornare vel eu leo.</td>
-      </tr>
-      <tr>
-        <th>
-          <a href="#">Person Name</a>
-        </th>
-        <td>1200</td>
-        <td>Vestibulum id ligula porta felis euismod semper. Donec ullamcorper
-          nulla non metus auctor fringilla.</td>
-      </tr>
-      <tr>
-        <th>Another Person</th>
-        <td>1500</td>
-        <td>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor
-          auctor. Nullam id dolor id nibh ultricies vehicula ut id elit.</td>
-      </tr>
-      <tr>
-        <th>Last One</th>
-        <td>2800</td>
-        <td>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Cras
-          mattis consectetur purus sit amet fermentum.</td>
-      </tr>
-      </tbody>
-    </table>
-  </div>
-  <div class="column">
-    <table>
-      <caption>This is a default table.</caption>
-      <thead>
-      <tr>
-        <th>Person</th>
-        <th>Number</th>
-        <th>Third Column</th>
-      </tr>
-      </thead>
-      <tbody>
-      <tr>
-        <th>Someone Lastname</th>
-        <td>900</td>
-        <td>Nullam quis risus eget urna mollis ornare vel eu leo.</td>
-      </tr>
-      <tr>
-        <th>
-          <a href="#">Person Name</a>
-        </th>
-        <td>1200</td>
-        <td>Vestibulum id ligula porta felis euismod semper. Donec ullamcorper
-          nulla non metus auctor fringilla.</td>
-      </tr>
-      <tr>
-        <th>Another Person</th>
-        <td>1500</td>
-        <td>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor
-          auctor. Nullam id dolor id nibh ultricies vehicula ut id elit.</td>
-      </tr>
-      <tr>
-        <th>Last One</th>
-        <td>2800</td>
-        <td>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Cras
-          mattis consectetur purus sit amet fermentum.</td>
-      </tr>
-      </tbody>
-    </table>
-  </div>
-  <div class="column">
+    <h2>Table in a container.</h2>
     <table>
       <caption>This is a default table.</caption>
       <thead>
@@ -801,14 +775,11 @@
 
 <style>
 @media screen and (min-width: 40em) {
-  .row {
-    display: flex;
-    flex-basis: 100%;
-    flex-wrap: wrap;
+  .container {
+    max-width: 1310px;
   }
-
   .column {
-    flex: 0 1 32.66%;
+    width: 450px;
   }
 }
 </style>

--- a/src/components/tables/tables.twig
+++ b/src/components/tables/tables.twig
@@ -806,7 +806,7 @@
     flex-basis: 100%;
     flex-wrap: wrap;
   }
-  
+
   .column {
     flex: 0 1 32.66%;
   }

--- a/src/components/tables/tables.twig
+++ b/src/components/tables/tables.twig
@@ -800,13 +800,15 @@
 </div>
 
 <style>
-.row {
-  display: flex;
-  flex-basis: 100%;
-  flex-wrap: wrap;
-}
-
-.column {
-
+@media screen and (min-width: 40em) {
+  .row {
+    display: flex;
+    flex-basis: 100%;
+    flex-wrap: wrap;
+  }
+  
+  .column {
+    flex: 0 1 32.66%;
+  }
 }
 </style>

--- a/src/components/tables/tables.twig
+++ b/src/components/tables/tables.twig
@@ -498,188 +498,372 @@
   </table>
 
   <br/><br/>
-
-  <table class="table--hover-highlight table--gray-borders">
-    <thead>
-    <tr>
-      <th>Person</th>
-      <th>Number</th>
-      <th>Third Column</th>
-      <th>Fourth Column</th>
-      <th>Fifth Column</th>
-      <th>Sixth Column</th>
-      <th>Seventhth Column</th>
-      <th>Eighth Column</th>
-      <th>Ninth Column</th>
-      <th>Tenth Column</th>
-      <th>Eleventh Column</th>
-    </tr>
-    </thead>
-    <tbody>
-    <tr>
-      <th>Someone Lastname</th>
-      <td>900</td>
-      <td>9999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-    </tr>
-    <tr>
-      <th>
-        <a href="#">Person Name</a>
-      </th>
-      <td>1200</td>
-      <td>9999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-    </tr>
-    <tr>
-      <th>Another Person</th>
-      <td>1500</td>
-      <td>9999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-    </tr>
-    <tr>
-      <th>some other person</th>
-      <td>2800</td>
-      <td>9999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-    </tr>
-    <tr>
-      <th>Someone and a Lastname</th>
-      <td>500</td>
-      <td>9999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-    </tr>
-    <tr>
-      <th>
-        <a href="#">Linked Name</a>
-      </th>
-      <td>1720</td>
-      <td>9999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-    </tr>
-    <tr>
-      <th>Another random person</th>
-      <td>1200</td>
-      <td>9999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-    </tr>
-    <tr>
-      <th>Some other Person</th>
-      <td>2200</td>
-      <td>9999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-    </tr>
-    <tr>
-      <th>Firstname and something</th>
-      <td>920</td>
-      <td>9999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-    </tr>
-    <tr>
-      <th>
-        <a href="#">Linked Other Name</a>
-      </th>
-      <td>1208</td>
-      <td>9999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-    </tr>
-    <tr>
-      <th>Another Person Randomly selected</th>
-      <td>1550</td>
-      <td>9999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-    </tr>
-    <tr>
-      <th>Last One</th>
-      <td>2830</td>
-      <td>9999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-      <td>1999</td>
-    </tr>
-    </tbody>
-  </table>
+  <h2>Responsive table</h2>
+  <div class="table-responsive">
+    <table class="table--hover-highlight table--gray-borders">
+      <thead>
+      <tr>
+        <th>Person</th>
+        <th>Number</th>
+        <th>Third Column</th>
+        <th>Fourth Column</th>
+        <th>Fifth Column</th>
+        <th>Sixth Column</th>
+        <th>Seventhth Column</th>
+        <th>Eighth Column</th>
+        <th>Ninth Column</th>
+        <th>Tenth Column</th>
+        <th>Eleventh Column</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <th>Someone Lastname</th>
+        <td>900</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>
+          <a href="#">Person Name</a>
+        </th>
+        <td>1200</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>Another Person</th>
+        <td>1500</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>some other person</th>
+        <td>2800</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>Someone and a Lastname</th>
+        <td>500</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>
+          <a href="#">Linked Name</a>
+        </th>
+        <td>1720</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>Another random person</th>
+        <td>1200</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>Some other Person</th>
+        <td>2200</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>Firstname and something</th>
+        <td>920</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>
+          <a href="#">Linked Other Name</a>
+        </th>
+        <td>1208</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>Another Person Randomly selected</th>
+        <td>1550</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      <tr>
+        <th>Last One</th>
+        <td>2830</td>
+        <td>9999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+        <td>1999</td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+  <br/><br/>
+{#  <table class="table--hover-highlight table--gray-borders">#}
+{#    <thead>#}
+{#    <tr>#}
+{#      <th>Person</th>#}
+{#      <th>Number</th>#}
+{#      <th>Third Column</th>#}
+{#      <th>Fourth Column</th>#}
+{#      <th>Fifth Column</th>#}
+{#      <th>Sixth Column</th>#}
+{#      <th>Seventhth Column</th>#}
+{#      <th>Eighth Column</th>#}
+{#      <th>Ninth Column</th>#}
+{#      <th>Tenth Column</th>#}
+{#      <th>Eleventh Column</th>#}
+{#    </tr>#}
+{#    </thead>#}
+{#    <tbody>#}
+{#    <tr>#}
+{#      <th>Someone Lastname</th>#}
+{#      <td>900</td>#}
+{#      <td>9999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#    </tr>#}
+{#    <tr>#}
+{#      <th>#}
+{#        <a href="#">Person Name</a>#}
+{#      </th>#}
+{#      <td>1200</td>#}
+{#      <td>9999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#    </tr>#}
+{#    <tr>#}
+{#      <th>Another Person</th>#}
+{#      <td>1500</td>#}
+{#      <td>9999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#    </tr>#}
+{#    <tr>#}
+{#      <th>some other person</th>#}
+{#      <td>2800</td>#}
+{#      <td>9999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#    </tr>#}
+{#    <tr>#}
+{#      <th>Someone and a Lastname</th>#}
+{#      <td>500</td>#}
+{#      <td>9999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#    </tr>#}
+{#    <tr>#}
+{#      <th>#}
+{#        <a href="#">Linked Name</a>#}
+{#      </th>#}
+{#      <td>1720</td>#}
+{#      <td>9999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#    </tr>#}
+{#    <tr>#}
+{#      <th>Another random person</th>#}
+{#      <td>1200</td>#}
+{#      <td>9999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#    </tr>#}
+{#    <tr>#}
+{#      <th>Some other Person</th>#}
+{#      <td>2200</td>#}
+{#      <td>9999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#    </tr>#}
+{#    <tr>#}
+{#      <th>Firstname and something</th>#}
+{#      <td>920</td>#}
+{#      <td>9999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#    </tr>#}
+{#    <tr>#}
+{#      <th>#}
+{#        <a href="#">Linked Other Name</a>#}
+{#      </th>#}
+{#      <td>1208</td>#}
+{#      <td>9999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#    </tr>#}
+{#    <tr>#}
+{#      <th>Another Person Randomly selected</th>#}
+{#      <td>1550</td>#}
+{#      <td>9999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#    </tr>#}
+{#    <tr>#}
+{#      <th>Last One</th>#}
+{#      <td>2830</td>#}
+{#      <td>9999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#      <td>1999</td>#}
+{#    </tr>#}
+{#    </tbody>#}
+{#  </table>#}
 
   <br/><br/>
 
@@ -775,6 +959,12 @@
 
 <style>
 @media screen and (min-width: 40em) {
+  @media (min-width: 84.375em) {
+    .container {
+      max-width:81.875em;
+      margin: 0 auto
+    }
+  }
   .container {
     max-width: 1310px;
   }

--- a/src/components/tables/tables.twig
+++ b/src/components/tables/tables.twig
@@ -1,11 +1,11 @@
-<table class="table">
-  <caption>Tables can have captions now.</caption>
+<table>
+  <caption>This is a default table.</caption>
   <thead>
-    <tr>
-      <th>Person</th>
-      <th>Number</th>
-      <th>Third Column</th>
-    </tr>
+  <tr>
+    <th>Person</th>
+    <th>Number</th>
+    <th>Third Column</th>
+  </tr>
   </thead>
   <tbody>
   <tr>
@@ -35,10 +35,8 @@
   </tr>
   </tbody>
 </table>
-
-<br/><br/>
-
-<table class="table table--gray-borders table--width-default">
+<br>
+<table class="table--gray-borders table--width-default">
   <caption>Tables can have captions now.</caption>
   <thead>
   <tr>
@@ -78,7 +76,7 @@
 
 <br/><br/>
 
-<table class="table table--gray-borders table--static">
+<table class="table--gray-borders table--static">
   <caption class="element-invisible">Tables can have captions now.</caption>
   <thead>
   <tr>
@@ -118,7 +116,7 @@
 
 <br/><br/>
 
-<table class="table table--is-striped table--static table--width-default" summary="Undergraduate Cost of Attendence - Living on Campus Example Table">
+<table class="table--static table--width-default" summary="Undergraduate Cost of Attendence - Living on Campus Example Table">
   <caption><strong>Living On Campus - Example Table</strong></caption>
 	<thead>
     <tr><th scope="row">&nbsp;</th>
@@ -156,7 +154,7 @@
 
 <br/><br/>
 
-<table class="table table--is-striped table--static table--gray-borders" summary="Undergraduate Cost of Attendence - Living on Campus Example Table">
+<table class="table--static table--gray-borders" summary="Undergraduate Cost of Attendence - Living on Campus Example Table">
   <thead>
   <tr><th scope="row">&nbsp;</th>
     <th scope="col">Resident</th>
@@ -193,7 +191,7 @@
 
 <br/><br/>
 
-<table class="table is-striped">
+<table>
   <caption class="element-invisible">Tables can have captions now.</caption>
   <thead>
     <tr>
@@ -378,7 +376,7 @@
 
 <br/><br/>
 
-<table class="table table--is-striped table--width-default table--gray-borders">
+<table class="table--width-default table--gray-borders">
   <caption class="element-invisible">This table was given a default width</caption>
   <thead>
   <tr>
@@ -498,7 +496,7 @@
 
 <br/><br/>
 
-<table class="table table--is-striped table--hover-highlight table--gray-borders">
+<table class="table--hover-highlight table--gray-borders">
   <thead>
   <tr>
     <th>Person</th>

--- a/src/components/tables/tables.twig
+++ b/src/components/tables/tables.twig
@@ -677,3 +677,136 @@
   </tr>
   </tbody>
 </table>
+<br>
+<h2>Tables in a row</h2>
+<div class="row">
+  <div class="column">
+    <table>
+      <caption>This is a default table.</caption>
+      <thead>
+      <tr>
+        <th>Person</th>
+        <th>Number</th>
+        <th>Third Column</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <th>Someone Lastname</th>
+        <td>900</td>
+        <td>Nullam quis risus eget urna mollis ornare vel eu leo.</td>
+      </tr>
+      <tr>
+        <th>
+          <a href="#">Person Name</a>
+        </th>
+        <td>1200</td>
+        <td>Vestibulum id ligula porta felis euismod semper. Donec ullamcorper
+          nulla non metus auctor fringilla.</td>
+      </tr>
+      <tr>
+        <th>Another Person</th>
+        <td>1500</td>
+        <td>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor
+          auctor. Nullam id dolor id nibh ultricies vehicula ut id elit.</td>
+      </tr>
+      <tr>
+        <th>Last One</th>
+        <td>2800</td>
+        <td>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Cras
+          mattis consectetur purus sit amet fermentum.</td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="column">
+    <table>
+      <caption>This is a default table.</caption>
+      <thead>
+      <tr>
+        <th>Person</th>
+        <th>Number</th>
+        <th>Third Column</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <th>Someone Lastname</th>
+        <td>900</td>
+        <td>Nullam quis risus eget urna mollis ornare vel eu leo.</td>
+      </tr>
+      <tr>
+        <th>
+          <a href="#">Person Name</a>
+        </th>
+        <td>1200</td>
+        <td>Vestibulum id ligula porta felis euismod semper. Donec ullamcorper
+          nulla non metus auctor fringilla.</td>
+      </tr>
+      <tr>
+        <th>Another Person</th>
+        <td>1500</td>
+        <td>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor
+          auctor. Nullam id dolor id nibh ultricies vehicula ut id elit.</td>
+      </tr>
+      <tr>
+        <th>Last One</th>
+        <td>2800</td>
+        <td>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Cras
+          mattis consectetur purus sit amet fermentum.</td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="column">
+    <table>
+      <caption>This is a default table.</caption>
+      <thead>
+      <tr>
+        <th>Person</th>
+        <th>Number</th>
+        <th>Third Column</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <th>Someone Lastname</th>
+        <td>900</td>
+        <td>Nullam quis risus eget urna mollis ornare vel eu leo.</td>
+      </tr>
+      <tr>
+        <th>
+          <a href="#">Person Name</a>
+        </th>
+        <td>1200</td>
+        <td>Vestibulum id ligula porta felis euismod semper. Donec ullamcorper
+          nulla non metus auctor fringilla.</td>
+      </tr>
+      <tr>
+        <th>Another Person</th>
+        <td>1500</td>
+        <td>Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor
+          auctor. Nullam id dolor id nibh ultricies vehicula ut id elit.</td>
+      </tr>
+      <tr>
+        <th>Last One</th>
+        <td>2800</td>
+        <td>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Cras
+          mattis consectetur purus sit amet fermentum.</td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<style>
+.row {
+  display: flex;
+  flex-basis: 100%;
+  flex-wrap: wrap;
+}
+
+.column {
+
+}
+</style>


### PR DESCRIPTION
Resolves #509
Resolves #510 

# How to test

https://uids.brand.uiowa.edu/branches/feature_default_tables/components/detail/tables.html

Check different table examples. The previous responsive behavior has been removed in favor of a horizontal scroll that is in effect below the `sm` breakpoint. Sticky headers (top or left) will no longer work. Compare the tables with the current tables to see if anything appears broken in appearance.

There is a hidden example of using a wrapping div for adding horizontal scrolling to larger tables beyond the `sm` breakpoint. To view it, set the responsive variant to not be hidden locally in `src/components/tables/tables.config.yml` and view the resulting page that is added to the documentation.