### PR TITLE
Added a fix to caption with to work with table--width-default class a…

### DIFF
--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -93,9 +93,6 @@ table {
     text-transform: uppercase;
     background-color: #333;
     font-weight: bold;
-    .table--width-default & {
-      width: unset;
-    }
   }
 
   tbody tr:last-child td,
@@ -110,6 +107,9 @@ table {
 
   &.table--width-default {
     width: unset;
+    caption {
+      width: unset;
+    }
   }
 }
 

--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -93,6 +93,9 @@ table {
     text-transform: uppercase;
     background-color: #333;
     font-weight: bold;
+    .table--width-default & {
+      width: unset;
+    }
   }
 
   tbody tr:last-child td,

--- a/src/components/tables/tables.twig
+++ b/src/components/tables/tables.twig
@@ -915,6 +915,31 @@
 
   <br/><br/>
 
+  <h2>Table with default width</h2>
+  <table class="table--width-default">
+    <thead>
+    <tr>
+      <th>Year</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>2001</td>
+    </tr>
+    <tr>
+      <td>2002</td>
+    </tr>
+    <tr>
+      <td>2003</td>
+    </tr>
+    <tr>
+      <td>2004</td>
+    </tr>
+    </tbody>
+  </table>
+
+  <br/><br/>
+
   <div class="column">
     <h2>Table in a container.</h2>
     <table>

--- a/src/components/tables/tables.twig
+++ b/src/components/tables/tables.twig
@@ -915,9 +915,9 @@
 
   <br/><br/>
 
-  
   <h2>Table with default width</h2>
   <table class="table--width-default">
+    <caption>This is a default width table.</caption>
     <thead>
     <tr>
       <th>Year</th>

--- a/src/components/tables/tables.twig
+++ b/src/components/tables/tables.twig
@@ -915,6 +915,7 @@
 
   <br/><br/>
 
+  
   <h2>Table with default width</h2>
   <table class="table--width-default">
     <thead>


### PR DESCRIPTION
Resolves: https://github.com/uiowa/uids/issues/538

# How to test

- If the pages generate, check out https://uids.brand.uiowa.edu/branches/feature_table_hotfix/components/preview/tables.html or https://localhost:3000/components/preview/tables and look for the table with the heading "Table with default width" has a caption that does not extend full width of the page. 
