### PR TITLE
Feature:`<a>` hover adjustments for a11y

### DIFF
--- a/src/components/typography/paragraph/paragraph.scss
+++ b/src/components/typography/paragraph/paragraph.scss
@@ -36,7 +36,7 @@ a {
 
   &:hover,
   &:focus {
-    transition: color 0.2s ease-in-out,background-color 0.2s ease-in-out,border-bottom 0.2s ease-in-out,text-shadow 0.2s ease-in-out;
+    transition: color 0.2s ease-in-out;
     color: $secondary;
   }
 }

--- a/src/components/typography/paragraph/paragraph.scss
+++ b/src/components/typography/paragraph/paragraph.scss
@@ -36,7 +36,8 @@ a {
 
   &:hover,
   &:focus {
-    text-decoration: none;
+    transition: color 0.2s ease-in-out,background-color 0.2s ease-in-out,border-bottom 0.2s ease-in-out,text-shadow 0.2s ease-in-out;
+    color: $secondary;
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/uiowa/uids/issues/550. 

# How to test

- Go to https://localhost:3000/components/detail/paragraph and verify that the underline is present on link hover and the blue color changes to black. 