### PR TITLE
Intro Text Changes

### DIFF
--- a/src/components/typography/paragraph/paragraph.scss
+++ b/src/components/typography/paragraph/paragraph.scss
@@ -164,15 +164,15 @@ pre {
   font-weight: $font-weight-medium-bold;
   line-height: 1.3;
   font-size: 2.0rem;
-  font-size: containerClamp(1.6rem, 2.0rem);
+  font-size: containerClamp(1.6rem, 2.2rem);
   margin-top: 0;
 }
 
 .uids-component--light-intro,
 .element--light-intro {
   font-weight: $font-weight-light;
-  line-height: 1.3;
+  line-height: 1.4;
   font-size: 2.0rem;
-  font-size: containerClamp(1.6rem, 2.0rem);
+  font-size: containerClamp(1.6rem, 2.1rem);
   margin-top: 0;
 }

--- a/src/components/typography/paragraph/paragraph.scss
+++ b/src/components/typography/paragraph/paragraph.scss
@@ -163,7 +163,7 @@ pre {
   font-family: $font-family-serif;
   font-weight: $font-weight-medium-bold;
   line-height: 1.3;
-  font-size: 2.0rem;
+  font-size: 2.2rem;
   font-size: containerClamp(1.6rem, 2.2rem);
   margin-top: 0;
 }
@@ -172,7 +172,7 @@ pre {
 .element--light-intro {
   font-weight: $font-weight-light;
   line-height: 1.4;
-  font-size: 2.0rem;
+  font-size: 2.1rem;
   font-size: containerClamp(1.6rem, 2.1rem);
   margin-top: 0;
 }

--- a/src/components/typography/paragraph/paragraph.scss
+++ b/src/components/typography/paragraph/paragraph.scss
@@ -162,19 +162,17 @@ pre {
 .element--bold-intro {
   font-family: $font-family-serif;
   font-weight: $font-weight-medium-bold;
-  line-height: 1.2;
-  font-size: 2.5rem;
-  font-size: containerClamp(1.7rem, 2.5rem);
+  line-height: 1.3;
+  font-size: 2.0rem;
+  font-size: containerClamp(1.6rem, 2.0rem);
   margin-top: 0;
-  margin-bottom: 1.7rem;
 }
 
 .uids-component--light-intro,
 .element--light-intro {
   font-weight: $font-weight-light;
-  line-height: 1.2;
-  font-size: 2.5rem;
-  font-size: containerClamp(1.7rem, 2.5rem);
+  line-height: 1.3;
+  font-size: 2.0rem;
+  font-size: containerClamp(1.6rem, 2.0rem);
   margin-top: 0;
-  margin-bottom: 1.7rem;
 }


### PR DESCRIPTION
Proposed changes to Intro Text feature.

- Smaller font size. Feels odd to have the intro text larger than the H2.
- Increased line-height for spacing
- Removes additional margin-bottom and defaults to regular paragraph margin-bottom.

Before
<img width="548" alt="Screen Shot 2021-05-27 at 10 24 10 AM" src="https://user-images.githubusercontent.com/731952/119860084-9a410600-bedb-11eb-8f23-30e71954dfc2.png">

After
<img width="550" alt="Screen Shot 2021-05-27 at 10 50 28 AM" src="https://user-images.githubusercontent.com/731952/119860148-a7f68b80-bedb-11eb-9319-12beca7a3be1.png">

