### PR TITLE
Feature: Added `<ul>` modifier to remove bullet or number if used on ul or ol

### DIFF
--- a/src/components/typography/lists/lists.scss
+++ b/src/components/typography/lists/lists.scss
@@ -53,6 +53,13 @@ ul ul ul {
   list-style-type: square;
 }
 
+.element--list-none {
+  list-style: none;
+  li {
+    list-style: none;
+  }
+}
+
 dd {
   @include margin($left: $lg);
 }


### PR DESCRIPTION
Resolves https://github.com/uiowa/uids/issues/576. 

# How to test

- Go to https://uids.brand.uiowa.edu/branches/feature_ul_no_lists/components/detail/lists.html and add the class `element--list-none` to a `<ul>` or `<ol>` and verify that the bullet or number does not display. 