### PR TITLE
Feature: Added fix for card right/left with center alignment

### DIFF
--- a/src/components/card/card.config.yml
+++ b/src/components/card/card.config.yml
@@ -411,6 +411,30 @@ variants:
       card_media_classes: 'card__media--large'
     display:
       max-width: 1200px
+  - name: horizontal-large-centered-left
+    label: Horizontal left centered w/large image
+    context:
+      card_title: Getting to know Iowa's fall 2018 graduates
+      card_image: 'https://sandbox.prod.drupal.uiowa.edu/sites/sandbox.uiowa.edu/files/2021-03/feature1.jpg'
+      card_classes: 'bg--white card--media-left card--centered card'
+      card_content: <p>Applications can be submitted via Iowa’s web application portal, the Common Application, and Coalition App. Once submitted, <a href="/">you</a> can track the status of your application through MyUI, a one-stop resource for current and prospective Iowa students.</p>
+      card_date: June 14, 1984
+      card_subtitle: By the Office of Strategic Communication
+      card_media_classes: 'card__media--large'
+    display:
+      max-width: 1200px
+  - name: horizontal-large-centered-right
+    label: Horizontal right centered w/large image
+    context:
+      card_title: Getting to know Iowa's fall 2018 graduates
+      card_image: 'https://sandbox.prod.drupal.uiowa.edu/sites/sandbox.uiowa.edu/files/2021-03/feature1.jpg'
+      card_classes: 'bg--white card--media-right card--centered card'
+      card_content: <p>Applications can be submitted via Iowa’s web application portal, the Common Application, and Coalition App. Once submitted, <a href="/">you</a> can track the status of your application through MyUI, a one-stop resource for current and prospective Iowa students.</p>
+      card_date: June 14, 1984
+      card_subtitle: By the Office of Strategic Communication
+      card_media_classes: 'card__media--large'
+    display:
+      max-width: 1200px
   - name: horizontal_enclosed_small
     label: Horizontal enclosed w/small image
     context:

--- a/src/components/card/card.config.yml
+++ b/src/components/card/card.config.yml
@@ -413,6 +413,7 @@ variants:
       max-width: 1200px
   - name: horizontal-large-centered-left
     label: Horizontal left centered w/large image
+    hidden: true
     context:
       card_title: Getting to know Iowa's fall 2018 graduates
       card_image: 'https://sandbox.prod.drupal.uiowa.edu/sites/sandbox.uiowa.edu/files/2021-03/feature1.jpg'
@@ -425,6 +426,7 @@ variants:
       max-width: 1200px
   - name: horizontal-large-centered-right
     label: Horizontal right centered w/large image
+    hidden: true
     context:
       card_title: Getting to know Iowa's fall 2018 graduates
       card_image: 'https://sandbox.prod.drupal.uiowa.edu/sites/sandbox.uiowa.edu/files/2021-03/feature1.jpg'

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -69,17 +69,6 @@
 
   &--centered {
     text-align: center;
-
-    &.card--media-left,
-    &.card--media-right {
-      flex-direction: column;
-
-      .card__media+.card__body {
-        @include breakpoint(sm) {
-          padding: 2rem 0 0;
-        }
-      }
-    }
   }
 
   &__title {


### PR DESCRIPTION
This resolves an issue with using left/right media alignment with content centering on the cards. 

![CaptureWhatiSee](https://user-images.githubusercontent.com/1036433/123432209-be057380-d58f-11eb-99fb-277c4d91e4c1.JPG)

# How to test

Go to the pages below and verify that they don't look like the garbled screenshot above:

- https://uids.brand.uiowa.edu/branches/feature-card-fix/components/detail/card--horizontal-large-centered-left.html
- https://uids.brand.uiowa.edu/branches/feature-card-fix/components/detail/card--horizontal-large-centered-right.html