### PR TITLE
Update to card images

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -289,7 +289,7 @@
     .card__media--small {
       &.media--circle {
         flex: unset;
-        width: auto;
+        width: 40%;
       }
     }
     .card__media--medium {


### PR DESCRIPTION
resolves https://github.com/uiowa/uiowa/issues/4748.

Adds width to small stacked images so the empty profile image doesn't disappear.