### PR TITLE
Feature: A few misc follow-ups to links on gray background colors

### DIFF
--- a/src/components/background/background.scss
+++ b/src/components/background/background.scss
@@ -59,18 +59,18 @@
 }
 
 // override gray link color.
-[class*="bg--white"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
-[class*="bg-"] [class*="bg--white"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
-[class*="bg--gray"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
-[class*="bg-"] [class*="bg--gray"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn) {
+[class*="bg--white"] :where(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
+[class*="bg-"] [class*="bg--white"] :where(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
+[class*="bg--gray"] :where(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
+[class*="bg-"] [class*="bg--gray"] :where(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn) {
   color: $link-color;
 }
 
 // set link color for black and gold nesting.
-[class*="bg--white"] [class*="bg--gold"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
-[class*="bg--white"] [class*="bg--black"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
-[class*="bg--gray"] [class*="bg--gold"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
-[class*="bg--gray"] [class*="bg--black"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn) {
+[class*="bg--white"] [class*="bg--gold"] :where(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
+[class*="bg--white"] [class*="bg--black"] :where(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
+[class*="bg--gray"] [class*="bg--gold"] :where(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
+[class*="bg--gray"] [class*="bg--black"] :where(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn) {
   color: inherit;
 }
 

--- a/src/components/background/background.scss
+++ b/src/components/background/background.scss
@@ -59,18 +59,18 @@
 }
 
 // override gray link color.
-[class*="bg--white"] :is(p, ul, ol, dl, cite, tbody) a:not(.bttn),
-[class*="bg-"] [class*="bg--white"] :is(p, ul, ol, dl, cite, tbody) a:not(.bttn),
-[class*="bg--gray"] :is(p, ul, ol, dl, cite, tbody) a:not(.bttn),
-[class*="bg-"] [class*="bg--gray"] :is(p, ul, ol, dl, cite, tbody) a:not(.bttn) {
+[class*="bg--white"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
+[class*="bg-"] [class*="bg--white"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
+[class*="bg--gray"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
+[class*="bg-"] [class*="bg--gray"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn) {
   color: $link-color;
 }
 
 // set link color for black and gold nesting.
-[class*="bg--white"] [class*="bg--gold"] :is(p, ul, ol, dl, cite, tbody) a:not(.bttn),
-[class*="bg--white"] [class*="bg--black"] :is(p, ul, ol, dl, cite, tbody) a:not(.bttn),
-[class*="bg--gray"] [class*="bg--gold"] :is(p, ul, ol, dl, cite, tbody) a:not(.bttn),
-[class*="bg--gray"] [class*="bg--black"] :is(p, ul, ol, dl, cite, tbody) a:not(.bttn) {
+[class*="bg--white"] [class*="bg--gold"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
+[class*="bg--white"] [class*="bg--black"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
+[class*="bg--gray"] [class*="bg--gold"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn),
+[class*="bg--gray"] [class*="bg--black"] :is(p, ul, ol, dl, cite, tbody, figcaption) a:not(.bttn) {
   color: inherit;
 }
 

--- a/src/components/colors/colors.scss
+++ b/src/components/colors/colors.scss
@@ -42,6 +42,14 @@
   color: $secondary;
 }
 
+a.text--black {
+  color: $secondary;
+  [class*="bg-"] &,
+  [class*="bg-"] [class*="bg-"] & {
+    color: $secondary;
+  }
+}
+
 .text--white {
   color: $white;
 }

--- a/src/components/kitchen-sink/kitchen-sink.twig
+++ b/src/components/kitchen-sink/kitchen-sink.twig
@@ -14,7 +14,7 @@
     <blockquote><p>Blockquote Text</p></blockquote>
     <figcaption>Figcaption <a href="/">Link</a></figcaption>
     <table>
-      <caption>This is a default table.</caption>
+      <caption>This is a default table. <a href="#">Link</a> <p><a href="#">Link</a></p></caption>
       <thead>
       <tr>
         <th><a href="/">Person</a></th>

--- a/src/components/kitchen-sink/kitchen-sink.twig
+++ b/src/components/kitchen-sink/kitchen-sink.twig
@@ -12,6 +12,7 @@
     {% endfor %}
     <p>Iowa's <em>leadership</em> in both the <sub>arts and sciences</sub> fosters unique <u>resources</u>, like the <a href="https://uiowa.edu">College of Medicine's Arts and Humanities Program</a>, that will help <strong>you stand out.</strong></p>
     <blockquote><p>Blockquote Text</p></blockquote>
+    <figcaption>Figcaption <a href="/">Link</a></figcaption>
     <table>
       <caption>This is a default table.</caption>
       <thead>

--- a/src/components/menus/main-menu/main-menu.scss
+++ b/src/components/menus/main-menu/main-menu.scss
@@ -72,6 +72,15 @@
         margin-bottom: 0;
       }
 
+      a {
+        [class*="bg--white"] &,
+        [class*="bg--"] [class*="bg--white"] &,
+        [class*="bg--gray"] &,
+        [class*="bg--"] [class*="bg--gray"] & {
+          color: #333;
+        }
+      }
+
       li {
         font-size: 1.1rem;
         display: list-item;

--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -113,7 +113,8 @@ table {
     a,
     :where(p) a:not(.bttn) {
       color: $primary;
-      [class*="bg--"] & {
+      [class*="bg--"] &,
+      [class*="bg--"] [class*="bg--"] & {
         color: $primary;
       }
     }

--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -110,6 +110,13 @@ table {
     text-transform: uppercase;
     background-color: #333;
     font-weight: bold;
+    a,
+    :where(p) a:not(.bttn) {
+      color: $primary;
+      [class*="bg--"] & {
+        color: $primary;
+      }
+    }
   }
 
   tbody tr:last-child td,

--- a/src/components/typography/paragraph/paragraph.scss
+++ b/src/components/typography/paragraph/paragraph.scss
@@ -37,7 +37,6 @@ a {
 
 figcaption {
   font-size: 90%;
-  color: $dark;
   line-height: 1.5;
 }
 


### PR DESCRIPTION
Resolves https://github.com/uiowa/uiowa/issues/4455

# How to test

- Go to the kitchen sink and verify that the `<figcaption>` is readable on all background colors and links within are blue on white and gray backgrounds. https://uids.brand.uiowa.edu/branches/feature_figcaption_fix/components/preview/kitchen-sink.html. Try adding `bg--` colors to the body class and verify that the captions are still accessible. 
- Try adding `bg--white` and `bg--gray` background colors to https://uids.brand.uiowa.edu/branches/feature_figcaption_fix/components/preview/main-menu.html and verify that the link color does not turn blue. 
- Go to https://uids.brand.uiowa.edu/branches/feature_figcaption_fix/components/preview/kitchen-sink.html and verify that link color within table caption is gold on all background colors.  Try adding `bg--white` and `bg--gray` to the body class and verify that the table caption is still gold. 