### PR TITLE
refactor accordions to accept hash parameters

### DIFF
--- a/src/components/accordion/accordion--focus-test.twig
+++ b/src/components/accordion/accordion--focus-test.twig
@@ -1,0 +1,36 @@
+<div id="lipsum">
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi malesuada urna vitae convallis semper. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Ut lobortis hendrerit molestie. Aenean porttitor suscipit dapibus. Sed aliquet auctor scelerisque. Vestibulum vehicula urna eget nisl rhoncus, non cursus mauris tristique. Pellentesque at accumsan metus. Integer vitae nulla vitae metus semper volutpat id nec quam. Fusce iaculis aliquet sapien quis commodo. Nullam risus tortor, commodo vitae molestie ac, consectetur non eros. Etiam pharetra quis lectus vel semper. Nam nec lacus dolor.
+  </p>
+  <p>
+    Nullam dignissim nisi libero, a viverra velit euismod at. Sed blandit pharetra purus non molestie. Praesent elit sapien, mollis in lorem ornare, suscipit congue nunc. Maecenas sed dignissim augue. Ut luctus ultricies lectus quis pulvinar. Pellentesque porta ligula magna, sed efficitur arcu pulvinar ut. Pellentesque auctor, neque a malesuada lobortis, felis risus pretium ex, dictum vehicula purus enim non diam. Mauris vel ante eleifend leo pulvinar rutrum. Donec id varius neque. Nam eros ligula, ornare ut tempor sed, faucibus at mauris.
+  </p>
+  <p>
+    Etiam id libero ornare mi laoreet commodo nec eu sem. Nullam in purus vitae purus sodales iaculis. Sed vitae nunc tempor, fermentum ipsum et, vestibulum enim. Suspendisse ut iaculis tortor. Duis vitae congue arcu. Proin nec velit vel tellus mollis viverra imperdiet quis enim. Curabitur placerat eros id dapibus hendrerit. Pellentesque eget dictum felis, quis euismod lacus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Mauris fringilla eu odio non vehicula. Sed fringilla sed leo non mattis. Donec non aliquam eros, quis posuere dolor. Suspendisse condimentum libero non metus posuere, vel vestibulum elit commodo. Vestibulum accumsan nibh ac elit viverra vestibulum non at ex. Phasellus eu orci velit.
+  </p>
+  <p>
+    Fusce mattis ante mi, eu blandit ligula ullamcorper quis. Suspendisse eu ex a magna vulputate elementum non sed magna. Duis a nulla efficitur, gravida enim non, malesuada ipsum. Vivamus quis neque nisi. Proin venenatis eros quis eros lobortis, vel bibendum augue cursus. Curabitur enim libero, tincidunt ac volutpat sit amet, ullamcorper ut mauris. Nam dui lorem, ultricies eu nisl non, sollicitudin scelerisque tortor. Quisque vitae sodales lorem. Praesent lacinia, erat a fermentum fringilla, lacus magna luctus augue, id consequat augue velit non lacus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec eleifend lacus posuere sem euismod, id semper ligula placerat. Vivamus suscipit, ex et interdum pharetra, nunc velit lacinia arcu, vitae lacinia est ligula eu tortor.
+  </p>
+  <p>
+    Morbi lobortis malesuada tellus, nec fermentum odio. Aenean nunc ipsum, vulputate tristique erat at, egestas molestie enim. Morbi aliquam lectus quis arcu finibus blandit. Etiam consectetur porta sapien, eu elementum lacus vestibulum vel. Phasellus finibus rutrum dictum. Proin eu consequat massa. Donec at leo leo. In et volutpat velit. Ut a vulputate mi, non mollis quam. Integer eget ex vitae metus aliquam tempor quis in felis. In sapien dolor, mollis nec vulputate nec, consectetur vel turpis. Nulla dapibus a metus eget facilisis. Vestibulum quis augue vitae diam pretium volutpat. Sed ligula tellus, efficitur quis diam at, sagittis eleifend nisi. Pellentesque quis malesuada erat.
+  </p>
+</div>
+{% render '@accordion' with {
+} %}
+<div id="lipsum">
+  <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi malesuada urna vitae convallis semper. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Ut lobortis hendrerit molestie. Aenean porttitor suscipit dapibus. Sed aliquet auctor scelerisque. Vestibulum vehicula urna eget nisl rhoncus, non cursus mauris tristique. Pellentesque at accumsan metus. Integer vitae nulla vitae metus semper volutpat id nec quam. Fusce iaculis aliquet sapien quis commodo. Nullam risus tortor, commodo vitae molestie ac, consectetur non eros. Etiam pharetra quis lectus vel semper. Nam nec lacus dolor.
+  </p>
+  <p>
+    Nullam dignissim nisi libero, a viverra velit euismod at. Sed blandit pharetra purus non molestie. Praesent elit sapien, mollis in lorem ornare, suscipit congue nunc. Maecenas sed dignissim augue. Ut luctus ultricies lectus quis pulvinar. Pellentesque porta ligula magna, sed efficitur arcu pulvinar ut. Pellentesque auctor, neque a malesuada lobortis, felis risus pretium ex, dictum vehicula purus enim non diam. Mauris vel ante eleifend leo pulvinar rutrum. Donec id varius neque. Nam eros ligula, ornare ut tempor sed, faucibus at mauris.
+  </p>
+  <p>
+    Etiam id libero ornare mi laoreet commodo nec eu sem. Nullam in purus vitae purus sodales iaculis. Sed vitae nunc tempor, fermentum ipsum et, vestibulum enim. Suspendisse ut iaculis tortor. Duis vitae congue arcu. Proin nec velit vel tellus mollis viverra imperdiet quis enim. Curabitur placerat eros id dapibus hendrerit. Pellentesque eget dictum felis, quis euismod lacus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Mauris fringilla eu odio non vehicula. Sed fringilla sed leo non mattis. Donec non aliquam eros, quis posuere dolor. Suspendisse condimentum libero non metus posuere, vel vestibulum elit commodo. Vestibulum accumsan nibh ac elit viverra vestibulum non at ex. Phasellus eu orci velit.
+  </p>
+  <p>
+    Fusce mattis ante mi, eu blandit ligula ullamcorper quis. Suspendisse eu ex a magna vulputate elementum non sed magna. Duis a nulla efficitur, gravida enim non, malesuada ipsum. Vivamus quis neque nisi. Proin venenatis eros quis eros lobortis, vel bibendum augue cursus. Curabitur enim libero, tincidunt ac volutpat sit amet, ullamcorper ut mauris. Nam dui lorem, ultricies eu nisl non, sollicitudin scelerisque tortor. Quisque vitae sodales lorem. Praesent lacinia, erat a fermentum fringilla, lacus magna luctus augue, id consequat augue velit non lacus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec eleifend lacus posuere sem euismod, id semper ligula placerat. Vivamus suscipit, ex et interdum pharetra, nunc velit lacinia arcu, vitae lacinia est ligula eu tortor.
+  </p>
+  <p>
+    Morbi lobortis malesuada tellus, nec fermentum odio. Aenean nunc ipsum, vulputate tristique erat at, egestas molestie enim. Morbi aliquam lectus quis arcu finibus blandit. Etiam consectetur porta sapien, eu elementum lacus vestibulum vel. Phasellus finibus rutrum dictum. Proin eu consequat massa. Donec at leo leo. In et volutpat velit. Ut a vulputate mi, non mollis quam. Integer eget ex vitae metus aliquam tempor quis in felis. In sapien dolor, mollis nec vulputate nec, consectetur vel turpis. Nulla dapibus a metus eget facilisis. Vestibulum quis augue vitae diam pretium volutpat. Sed ligula tellus, efficitur quis diam at, sagittis eleifend nisi. Pellentesque quis malesuada erat.
+  </p>
+</div>

--- a/src/components/accordion/accordion--multiple.twig
+++ b/src/components/accordion/accordion--multiple.twig
@@ -1,0 +1,14 @@
+{% render '@accordion' with {
+} %}
+
+{% set names = {
+  0: 'strawberry',
+  1: 'blackberry',
+  2: 'raspberry',
+  3: 'blueberry',
+}
+%}
+
+{% render '@accordion' with {
+  'names': names,
+} %}

--- a/src/components/accordion/accordion.config.yml
+++ b/src/components/accordion/accordion.config.yml
@@ -27,3 +27,9 @@ variants:
     hidden: false
     context:
       multiselectable: true
+  - name: multiple
+    label: Multiple accordion sets
+    hidden: false
+  - name: focus-test
+    label: Accordion focus test
+    hidden: true

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -1,48 +1,156 @@
-function Accordion(element) {
-  this.panels = element.getElementsByClassName("accordion__heading");
-  this.multiSelectible = element.getAttribute('aria-multiselectable') === 'true' || false;
+(function () {
+  function Accordion(element) {
+    // Get the accordions, and if the accordion group is multiselectable.
+    this.accordions = element.getElementsByClassName("accordion__heading");
+    this.multiSelectible = element.getAttribute('aria-multiselectable') === 'true' || false;
 
-  for (let i = 0; i < this.panels.length; i++) {
+    // For each of the accordions...
+    for (let i = 0; i < this.accordions.length; i++) {
 
-    let btn = this.panels[i].querySelector('button');
-    let target = this.panels[i].nextElementSibling;
+      // Get the accordion item's components.
+      let itemComponents = this.accordionItemComponents(this.accordions[i]);
 
-    let expanded = btn.getAttribute('aria-expanded') === 'true' || false;
-    target.hidden = !expanded;
+      // Check if the accordion is currently expanded at moment of click.
+      let expanded = this.isAccordionOpen(itemComponents.btn);
 
-    btn.onclick = () => {
-      this.togglePanel(btn, target);
+      // If it is, un-hide its corresponding panel.
+      itemComponents.panel.hidden = !expanded;
+
+      // When the accordion's button is clicked...
+      itemComponents.btn.onclick = () => {
+
+        // Toggle the corresponding accordion.
+        this.toggleAccordion(this.accordions[i]);
+      }
+    }
+
+    // Activate any accordion that is defined in the hash parameter if there is one.
+    this.activateAccordionByHash();
+  }
+
+  // Gets the item components for 'accordion'.
+  // Returns an object that contains 'btn' and 'panel' elements.
+  Accordion.prototype.accordionItemComponents = function (accordion) {
+    let btn = accordion.querySelector('button');
+    let panel = accordion.nextElementSibling;
+
+    return {
+      'btn': btn,
+      'panel': panel
     }
   }
-}
 
-Accordion.prototype.togglePanel = function(btn, target) {
-  let expanded = btn.getAttribute('aria-expanded') === 'true' || false;
+  // Define whether 'accordion' is open with 'isOpen'.
+  Accordion.prototype.accordionOpen = function (accordion, isOpen) {
+    // Get the accordion item's components.
+    let itemComponents = this.accordionItemComponents(accordion);
 
-  // Checks if multiple panels can be open at once. If not, closes other panels.
-  if (!this.multiSelectible && !expanded) {
-    this.collapseAllPanels();
+    // Set the relevant attributes for 'accordion' based on 'isOpen'.
+    itemComponents.btn.setAttribute('aria-expanded', isOpen);
+    itemComponents.btn.setAttribute('aria-selected', isOpen);
+    itemComponents.panel.hidden = !isOpen;
   }
 
-  btn.setAttribute('aria-expanded', !expanded);
-  btn.setAttribute('aria-selected', !expanded);
-  target.hidden = expanded;
-}
+  // Activate an 'accordion'.
+  Accordion.prototype.activateAccordion = function (accordion) {
 
-Accordion.prototype.collapseAllPanels = function() {
-  for (let i = 0; i < this.panels.length; i++) {
-    let inner_target = this.panels[i].nextElementSibling;
-    let inner_btn = this.panels[i].querySelector('button');
-    inner_btn.setAttribute('aria-expanded', 'false');
-    inner_btn.setAttribute('aria-selected', 'false');
-    inner_target.hidden = true;
+    // Checks if multiple accordions can be open at once. If not, closes other accordions.
+    if (!this.multiSelectible) {
+      this.collapseAllAccordions();
+    }
+
+    // Open the accordion.
+    this.accordionOpen(accordion, true);
   }
-}
 
-// Instantiate accordions on the page.
-const accordions = document.getElementsByClassName("accordion");
+  // Activate any accordion that is defined in the hash parameter if there is one.
+  Accordion.prototype.activateAccordionByHash = function () {
 
-for (let i = 0; i < accordions.length; i++) {
-  let accordion = new Accordion(accordions[i]);
-}
+    // Get the hash parameter.
+    let hash = window.location.hash.substr(1);
+
+    // If the hash parameter is not empty...
+    if (hash !== '') {
+
+      // Get the accordion to focus.
+      let accordionToFocus = document.getElementById(hash);
+
+      // If the defined hash parameter finds an element...
+      if (accordionToFocus !== null) {
+
+        // Get the accordion wrapper of the hash parameter and this accordion wrapper to compare later.
+        let accordionToFocusAccordionWrapper = accordionToFocus.parentElement
+        let accordionWrapper = this.accordions[0].parentElement;
+
+        // If the accordion wrapper defined by the hash and this accordion wrapper are the same...
+        if (accordionToFocusAccordionWrapper === accordionWrapper) {
+
+          // Activate the accordion defined in the hash parameters.
+          this.activateAccordion(accordionToFocus);
+        }
+      }
+    }
+  }
+
+  // Collapse all accordions in this accordion group.
+  Accordion.prototype.collapseAllAccordions = function () {
+
+    // For each accordion...
+    for (let i = 0; i < this.accordions.length; i++) {
+
+      // Close it.
+      this.accordionOpen(this.accordions[i], false);
+    }
+  }
+
+  // Check if an accordion is open by inspecting the aria attribute of the 'btn' controlling it.
+  // Returns a boolean.
+  Accordion.prototype.isAccordionOpen = function (btn) {
+    return btn.getAttribute('aria-expanded') === 'true' || false;
+  }
+
+  // Toggle a specific 'accordion' open or closed.
+  Accordion.prototype.toggleAccordion = function (accordion) {
+    // Get the accordion's button element.
+    let btn = accordion.querySelector('button');
+
+    // Check if the accordion is currently expanded at moment of click.
+    let expanded = this.isAccordionOpen(btn);
+
+    // Checks if multiple accordions can be open at once. If not, closes other accordions.
+    if (!this.multiSelectible && !expanded) {
+      this.collapseAllAccordions();
+    }
+
+    // Toggle the accordion.
+    this.accordionOpen(accordion, !expanded)
+
+    // If the accordion is not open (but will be)...
+    if (!expanded) {
+
+      // Define historyString here to be used later.
+      let historyString = '#' + btn.parentElement.id;
+
+      // Change window location to add URL params
+      if (window.history && history.pushState && historyString !== '#') {
+        // NOTE: doesn't take into account existing params
+        history.replaceState("", "", historyString);
+      }
+    }
+
+    // Else if the accordion is closed...
+    else {
+
+      // Empty the history string.
+      history.replaceState("", "", " ");
+    }
+  }
+
+  // Instantiate accordions on the page.
+  const accordions = document.getElementsByClassName("accordion");
+
+  for (let i = 0; i < accordions.length; i++) {
+    let accordion = new Accordion(accordions[i]);
+  }
+}());
 

--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -1,5 +1,7 @@
 (function () {
   function Accordion(element) {
+    let thisAccordion = this;
+
     // Get the accordions, and if the accordion group is multiselectable.
     this.accordions = element.getElementsByClassName("accordion__heading");
     this.multiSelectible = element.getAttribute('aria-multiselectable') === 'true' || false;
@@ -23,6 +25,13 @@
         this.toggleAccordion(this.accordions[i]);
       }
     }
+
+    // Add a listener that listens for when the URL is changed.
+    window.addEventListener('popstate', function (event) {
+
+      // Activate an accordion based upon the hash parameters in the URL.
+      thisAccordion.activateAccordionByHash();
+    });
 
     // Activate any accordion that is defined in the hash parameter if there is one.
     this.activateAccordionByHash();

--- a/src/components/accordion/accordion.twig
+++ b/src/components/accordion/accordion.twig
@@ -4,15 +4,25 @@
   {% set accordion_type = 'single' %}
 {% endif %}
 
+{% if names is empty %}
+  {% set names = {
+    0: 'chocolate_chip',
+    1: 'sugar',
+    2: 'snickerdoodle',
+    3: 'oatmeal',
+  }
+  %}
+{% endif %}
+
 <div class="accordion
   {% if accordion.variant %} accordion--{{ variant }}{% endif %}"
   role="tablist"
   aria-multiselectable="{{ multiselectable }}"
 >
-  {% set item_number = 1 %}
+  {% set accordion_item_number = 0 %}
   {% for item in items %}
     <!-- Use the accurate heading level to maintain the document outline -->
-    <h2 id="accordion-heading-{{ item_number }}"
+    <h2 id="{{ names[accordion_item_number] }}"
       class="accordion__heading"
     >
       <button class="accordion__button"
@@ -26,11 +36,11 @@
       </button>
     </h2>
     <div id="{{ accordion_type }}-select-{{ item_number }}"
-      aria-labelledby="accordion-heading-{{ item_number }}"
+      aria-labelledby="{{ names[accordion_item_number] }}"
       class="accordion__content"
     >
       {{ item.content }}
     </div>
-    {% set item_number = item_number + 1 %}
+    {% set accordion_item_number = accordion_item_number + 1 %}
   {% endfor %}
 </div>

--- a/src/components/accordion/accordion.twig
+++ b/src/components/accordion/accordion.twig
@@ -1,4 +1,4 @@
-{% if accordion.multiselectable == true %}
+{% if multiselectable == true %}
   {% set accordion_type = 'multi' %}
 {% else %}
   {% set accordion_type = 'single' %}
@@ -15,7 +15,7 @@
 {% endif %}
 
 <div class="accordion
-  {% if accordion.variant %} accordion--{{ variant }}{% endif %}"
+  {% if multiselectable %} accordion--{{ accordion_type }}{% endif %}"
   role="tablist"
   aria-multiselectable="{{ multiselectable }}"
 >
@@ -29,13 +29,13 @@
         role="tab"
         aria-selected="{{ item.expanded | default('false') }}"
         aria-expanded="{{ item.expanded | default('false') }}"
-        aria-controls="{{ accordion_type }}-select-{{ item_number }}"
+        aria-controls="{{ accordion_type }}-select-{{ accordion_item_number }}"
       >
         {{ item.title }}
         <i aria-hidden="true" focusable="false" class="fas fa-chevron-up"></i>
       </button>
     </h2>
-    <div id="{{ accordion_type }}-select-{{ item_number }}"
+    <div id="{{ accordion_type }}-select-{{ accordion_item_number }}"
       aria-labelledby="{{ names[accordion_item_number] }}"
       class="accordion__content"
     >


### PR DESCRIPTION
This should start to be able to allow accordions to have hash parameter functionality.

## To test
- On https://localhost:3000/components/preview/accordion--default , test that clicking on different accordion items changes the hash parameter in the URL, and that closing an item clears the URL hash parameter.
- On the same page, check that changing the URL to another viable hash parameter also opens that accordion.
- Open a new tab and past in a URL of the page you just visited with a hash parameter and verify that the correct accordion item opens.
- On the same page, disable JS and CSS and verify that you can see all the accordion data, even if it is ugly.
- On https://localhost:3000/components/preview/accordion--multi , verify that clicking on different accordion items changes the hash parameter in the URL, and that closing an item clears the URL hash parameter. 
- On On https://localhost:3000/components/preview/accordion--multiple , verify that the new `id`'s do not collide or create any problems. There should be support for custom `id`s.
- On https://localhost:3000/components/preview/accordion--focus-test#snickerdoodle , check to see that you are brought to the open accordion item.
- On any page, try to break things and report any breaking here! (THANK YOU)