### PR TITLE
Setup 3.x branch

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,7 @@ name: Update documentation in GitHub Pages
 on:
   push:
     branches:
-      - "main"
+      - "3.x"
     tags:
       - '*'
   pull_request:
@@ -25,7 +25,7 @@ jobs:
       (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     env:
       TARGET_BRANCH: gh-pages
-      MAIN_BRANCH: main
+      MAIN_BRANCH: 3.x
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Updates to get the `3.x` branch ready to replace the `main` branch.

Related to #671.

# To test
Review code changes and observe successful build.