### PR TITLE
Feature table updates

### DIFF
--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -218,5 +218,4 @@ table.table--gray-borders {
     }
   }
 
-    th, td {
 }

--- a/src/components/tables/tables.scss
+++ b/src/components/tables/tables.scss
@@ -18,6 +18,7 @@ table {
   color: $secondary;
   display: inline-block;
   font-size: $content-font-size;
+  line-height: 1.15;
   max-width: 100%;
   overflow-x: auto;
   // @todo Add white-space: nowrap?
@@ -217,9 +218,5 @@ table.table--gray-borders {
     }
   }
 
-  & > tbody > tr:first-child {
     th, td {
-      border-top: none;
-    }
-  }
 }

--- a/src/components/tables/tables.twig
+++ b/src/components/tables/tables.twig
@@ -1101,6 +1101,28 @@
     </tbody>
   </table>
 
+<br/><br/>
+
+  <table class="table--gray-borders">
+    <tbody>
+    <tr>
+      <td>Year</td>
+    </tr>
+    <tr>
+      <td>2001</td>
+    </tr>
+    <tr>
+      <td>2002</td>
+    </tr>
+    <tr>
+      <td>2003</td>
+    </tr>
+    <tr>
+      <td>2004</td>
+    </tr>
+    </tbody>
+  </table>
+
   <br/><br/>
 
   <h2>Table with default width</h2>


### PR DESCRIPTION
Fix for #705 

Adds a border top back when using the table--gray-borders class. The only issue I've seen with this is when you have a caption that has the class "element-invisible" the top border doubles up. I don't see this as an issue since it is impossible for a user to add this class to a caption in the wysiwyg editor.

I also set a default line-height for tables to be the default body line-height which is 1.15. I noticed that tables created in the main body content area had a line-height of 1.7 but tables created within a component like the Text Area or Collection have 1.15. The main body content table are getting a line-height set by a class ".text-formatted div" of 1.7. I'm open to ideas on what the default should be but I set it as 1.15 for now.