### PR TITLE
Feature: Removed button full class from example page

### DIFF
--- a/src/components/card/card.twig
+++ b/src/components/card/card.twig
@@ -88,7 +88,7 @@
       {% if card_link_url is not empty and show_button %}
         {% set button_classes = 'bttn bttn--outline bttn--sans-serif' %}
         {% if link_element == 'button' %}
-          <a class="{{ button_classes }} click-target bttn--full" href="{{ card_link_url }}">
+          <a class="{{ button_classes }} click-target" href="{{ card_link_url }}">
             {{ card_link_title }}
             <i class="fas fa-arrow-right"></i>
           </a>


### PR DESCRIPTION
# How to test


Review code and verify that full-width class has been removed. 

Resolves this issue:
<img width="1759" alt="Screen Shot 2022-08-01 at 11 45 58 AM" src="https://user-images.githubusercontent.com/1036433/182200936-a0017d47-3bd5-4913-bfb5-78ef13bfb72a.png">

