### PR TITLE
Feature: Moved blockquote footer formatting to html tags

### DIFF
--- a/src/assets/scss/theme.scss
+++ b/src/assets/scss/theme.scss
@@ -8,7 +8,7 @@
 @import 'branding/logo/logo.scss';
 @import 'branding/site-name/site-name.scss';
 @import 'branding/iowa-bar/iowa-bar.scss';
-@import 'menus/off-canvas/off-canvas.scss';
+@import 'menus/toggle-nav/toggle-nav.scss';
 
 $header-height: 50px;
 

--- a/src/assets/scss/uids.scss
+++ b/src/assets/scss/uids.scss
@@ -42,7 +42,7 @@ $imgpath: '../../assets/images';
 'menus/group/group',
 'menus/internal-navigation/internal-navigation',
 'menus/main-menu/main-menu.scss',
-'menus/off-canvas/off-canvas.scss',
+'menus/toggle-nav/toggle-nav.scss',
 'menus/quick/quick',
 'menus/top/top.scss',
 'menus/user-menu/user-menu',

--- a/src/components/blockquote/blockquote.config.yml
+++ b/src/components/blockquote/blockquote.config.yml
@@ -9,7 +9,7 @@ meta:
       - /components/media/media.css
 context:
       blockquote_content:  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-      blockquote_footer: Footer Details in Roboto
+      blockquote_footer: <strong>Footer Details in Roboto</strong>
       blockquote_cite_url: https://uiowa.edu/
       blockquote_cite_text: Link
       blockquote_image: https://sandbox.prod.drupal.uiowa.edu/sites/sandbox.uiowa.edu/files/2021-03/events-01.jpg

--- a/src/components/blockquote/blockquote.scss
+++ b/src/components/blockquote/blockquote.scss
@@ -53,7 +53,6 @@ blockquote {
 
   footer {
     font-family: $font-family-sans-serif;
-    font-weight: $font-weight-bold;
     margin-top: $md;
     font-size: $content-font-size;
   }


### PR DESCRIPTION
# How to test

Code review to verify that `font-weight: 700` has been replaced by a `<strong>` tag in the template. 