### PR TITLE
Use dependabot on both main branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,17 @@
 version: 2
 updates:
 - package-ecosystem: npm
+  target_branch: "4.x"
+  pull-request-branch-name:
+    separator: "-"
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "14:00"
+    timezone: America/Chicago
+  open-pull-requests-limit: 10
+- package-ecosystem: npm
+  target_branch: "3.x"
   pull-request-branch-name:
     separator: "-"
   directory: "/"


### PR DESCRIPTION
Hopefully this will allow @dependabot to check both the 3.x and 4.x branches and open pull requests against them.