### PR TITLE
Update 3.x build process to remove step that sets up building to `latest`

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -41,14 +41,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Set variables for main
-        if: |
-          github.event_name == 'push' &&
-          github.ref == format('refs/heads/{0}', env.MAIN_BRANCH)
-        run: |
-          echo "branch=latest" >> $GITHUB_ENV
-          echo "target_dir=/" >> $GITHUB_ENV
-
       - name: Set variables for branches
         if: |
           github.event_name == 'pull_request' ||
@@ -101,7 +93,7 @@ jobs:
 #      - run: echo "Branch check - ${{ contains(github.ref, 'refs/heads/') && github.ref != format('refs/heads/{0}', env.MAIN_BRANCH) }}"
 #      - run: echo "Tags check - ${{ startsWith(github.ref, 'refs/tags/') }}
 
-      # Only one of the following 3 steps should run.
+      # Only one of the following 2 steps should run.
 
       # If tags:
       #   - Copy the build to the root of 'gh-pages'.


### PR DESCRIPTION
Updates the build process for the 3.x branch so that it should no longer build to the `latest` directory, so that we can use that to view the most recent version of the 4.x branch.

# To test

Code review.