### PR TITLE
PR to trigger a 4.x build to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,3 @@ If you are starting work on a new component, please make sure that it has `statu
 GitHub Actions is used to build and deploy the Fractal artifact to the `gh-pages` branch. This branch is set to host UIDS using GitHub Pages. All pushes to a branches or tags will trigger a build.
 
 Branches can be accessed at http://uids.brand.uiowa.edu/branches/{your-branch-name}.
-


### PR DESCRIPTION
This is a follow-up to #848 to setup 4.x in the `latest` path so we always have a live version of 4.x available.