### PR TITLE
3x build update

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,8 @@ jobs:
     # Otherwise, clone it normally.
     if: |
       (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
-      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
+      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]') ||
+      !(github.event_name == 'push' && github.ref == format('refs/heads/{0}', env.MAIN_BRANCH))
     env:
       TARGET_BRANCH: gh-pages
       MAIN_BRANCH: 3.x

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,7 +23,7 @@ jobs:
     if: |
       ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
       (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')) &&
-      !(github.event_name == 'push' && github.ref == format('refs/heads/{0}', env.MAIN_BRANCH))
+      github.ref != format('refs/heads/{0}', env.MAIN_BRANCH)
     env:
       TARGET_BRANCH: gh-pages
       MAIN_BRANCH: 3.x

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]".
-    # Otherwise, clone it normally.
+    # Otherwise, clone it normally. Also, skip the 3.x branch, so we don't build that to latest anymore.
     if: |
       ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
       || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,8 +22,9 @@ jobs:
     # Otherwise, clone it normally.
     if: |
       ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
-      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')) &&
-      github.ref != format('refs/heads/{0}', env.MAIN_BRANCH)
+      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
+#      &&
+#      github.ref != format('refs/heads/{0}', env.MAIN_BRANCH)
     env:
       TARGET_BRANCH: gh-pages
       MAIN_BRANCH: 3.x
@@ -87,7 +88,7 @@ jobs:
           path: gh-pages
 
       # Debugging messages.
-#      - run: echo "${{ github.ref }}"
+      - run: echo "${{ github.ref }}"
 #      - run: echo "${{ toJson(github) }}"
 #      - run: echo "${{ env.MAIN_BRANCH }}"
 #      - run: echo "Main check - ${{ github.ref == format('refs/heads/{0}', env.MAIN_BRANCH) }}"

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,8 +21,9 @@ jobs:
     # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]".
     # Otherwise, clone it normally.
     if: |
-      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
-      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
+      ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
+      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')) &&
+      !(github.event_name == 'push' && github.ref == format('refs/heads/{0}', env.MAIN_BRANCH))
     env:
       TARGET_BRANCH: gh-pages
       MAIN_BRANCH: 3.x

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
     # Otherwise, clone it normally.
     if: |
       (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
-      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]') ||
+      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]') &&
       !(github.event_name == 'push' && github.ref == format('refs/heads/{0}', env.MAIN_BRANCH))
     env:
       TARGET_BRANCH: gh-pages

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,8 +23,8 @@ jobs:
     if: |
       ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
       (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
-#      &&
-#      github.ref != format('refs/heads/{0}', env.MAIN_BRANCH)
+      &&
+      github.ref != 'refs/heads/3.x'
     env:
       TARGET_BRANCH: gh-pages
       MAIN_BRANCH: 3.x

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,8 +22,7 @@ jobs:
     # Otherwise, clone it normally.
     if: |
       (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
-      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]') &&
-      !(github.event_name == 'push' && github.ref == format('refs/heads/{0}', env.MAIN_BRANCH))
+      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     env:
       TARGET_BRANCH: gh-pages
       MAIN_BRANCH: 3.x

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,10 +21,9 @@ jobs:
     # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]".
     # Otherwise, clone it normally.
     if: |
-      ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
-      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
-      &&
-      github.ref != 'refs/heads/3.x'
+      ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
+      && github.ref != 'refs/heads/3.x'
     env:
       TARGET_BRANCH: gh-pages
       MAIN_BRANCH: 3.x
@@ -88,7 +87,7 @@ jobs:
           path: gh-pages
 
       # Debugging messages.
-      - run: echo "${{ github.ref }}"
+#      - run: echo "${{ github.ref }}"
 #      - run: echo "${{ toJson(github) }}"
 #      - run: echo "${{ env.MAIN_BRANCH }}"
 #      - run: echo "Main check - ${{ github.ref == format('refs/heads/{0}', env.MAIN_BRANCH) }}"


### PR DESCRIPTION
Adds a condition to prevent the job from running if the 3.x branch is being merged into. The only way to update the main documentation is through releases.

# To test
Code review.