### PR TITLE
Make the click-a11y script callable

### DIFF
--- a/src/assets/js/click-a11y.js
+++ b/src/assets/js/click-a11y.js
@@ -1,9 +1,10 @@
-const items = document.querySelectorAll('.click-container:not([data-uids-no-link])');
-const link_elements = ['.click-target'];
 const RIGHT_BUTTON_CODE = 2;
 
+/**
+ * A class for setting click targets.
+ */
 class A11yClickTarget {
-  constructor(item) {
+  constructor(item, link_elements) {
     let up, down, link, i;
     // Loop through options and break on the first match.
     for (i = 0; i < link_elements.length; i++) {
@@ -41,8 +42,17 @@ class A11yClickTarget {
   }
 }
 
-Array.prototype.forEach.call(items, item => {
-  new A11yClickTarget(item);
-});
+/**
+ * Initializes the click target on the specified selectors.
+ *
+ * @param selector
+ * @param link_elements
+ */
+function applyClickA11y(selector, link_elements = ['.click-target']) {
+  const items = document.querySelectorAll(selector);
+  Array.prototype.forEach.call(items, (item) => {
+    new A11yClickTarget(item, link_elements);
+  });
+}
 
-export default A11yClickTarget
+export { applyClickA11y }

--- a/src/components/card/Card.vue
+++ b/src/components/card/Card.vue
@@ -212,7 +212,7 @@ onMounted(() => {
 
     <div class="card__body">
       <header v-if="$slots.title">
-        <uids-headline :text_style="headline_style" class='test'>
+        <uids-headline :text_style="headline_style">
           <!-- @slot The title of the card. HTML is allowed. -->
           <a v-if="headlineLink" :href="headlineLink" class="click-target">
             <slot name="title">Title</slot>

--- a/src/components/card/Card.vue
+++ b/src/components/card/Card.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, useSlots } from 'vue'
+import { computed, onMounted, useSlots } from 'vue';
 import { className } from '../utlity'
 import UidsHeadline from '../headline/Headline.vue'
 import UidsButton from '../button/Button.vue'
@@ -10,6 +10,7 @@ import Media from '../shared/media'
 import './card.scss'
 import '../background/background.scss'
 import '../media/media.scss'
+import { applyClickA11y } from '../../assets/js/click-a11y'
 
 const name = 'uids-card'
 const props = defineProps({
@@ -127,6 +128,10 @@ const buttonClasses = computed(() => {
     classes.push('bttn--no-text')
   }
 
+  if (linkedElement.value === 'button') {
+    classes.push('click-target')
+  }
+
   return classes
 })
 
@@ -173,6 +178,13 @@ const detailsElement = computed(() => {
   }
   return false;
 });
+
+onMounted(() => {
+  if (props.url) {
+    applyClickA11y('.click-container:not([data-uids-no-link])');
+  }
+});
+
 </script>
 
 <template>
@@ -185,23 +197,35 @@ const detailsElement = computed(() => {
         <a
           v-if="linkedElement === 'image'"
           :href="url"
+          class="click-target"
         >
           <!-- @slot Media displayed at the top of the card. -->
           <slot name="media"></slot>
         </a>
         <!-- @slot Media displayed at the top of the card. -->
-        <slot name="media" v-else></slot>
+        <slot
+          name="media"
+          v-else
+        ></slot>
       </div>
     </div>
 
     <div class="card__body">
       <header v-if="$slots.title">
-        <uids-headline :url="headlineLink" :text_style="headline_style">
+        <uids-headline :text_style="headline_style" class='test'>
           <!-- @slot The title of the card. HTML is allowed. -->
-          <slot name="title">Title</slot>
+          <a v-if="headlineLink" :href="headlineLink" class="click-target">
+            <slot name="title">Title</slot>
+          </a>
+          <template v-else>
+            <slot name="title">Title</slot>
+          </template>
         </uids-headline>
       </header>
-      <div v-if="detailsElement === true" class="card__details">
+      <div
+        v-if="detailsElement === true"
+        class="card__details"
+      >
         <div v-if="$slots.subtitle" class="card__subtitle">
           <!-- @slot The subtitle of the card.. -->
           <slot name="subtitle">Subtitle</slot>

--- a/src/components/headline/Headline.vue
+++ b/src/components/headline/Headline.vue
@@ -11,16 +11,6 @@ const props = defineProps({
       return ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].indexOf(value) !== -1
     },
   },
-  class: {
-    type: String,
-  },
-  url: {
-    type: String,
-  },
-  aria_describedby: {
-    type: [String, Boolean],
-    default: false,
-  },
   highlight: {
     type: Boolean,
     default: false,
@@ -49,15 +39,6 @@ const getClasses = computed(() => ({
     :is="level"
     :class="getClasses"
   >
-    <a
-      v-if="url"
-      :href="url"
-      :aria-describedby="aria_describedby"
-    >
-      <slot></slot>
-    </a>
-    <template v-else>
-      <slot></slot>
-    </template>
+    <slot></slot>
   </component>
 </template>


### PR DESCRIPTION
Resolves #856.

Also, as part of this work, the headline component was updated to not include properties related to the content containing a link or not. Since the inclusion of the link doesn't have any affect on how the headline gets styled, we can just let the headline component be a wrapper around whatever text or link gets inserted into and avoid having the extra logic related to applying properties based on the link.

# To test

Using https://uids.brand.uiowa.edu/branches/callable_click_a11y/ to test:
- Check card examples against https://uids.brand.uiowa.edu/latest/ to see if there are any regressions.
- Confirm that unlinked card is not linked: https://uids.brand.uiowa.edu/branches/callable_click_a11y/?path=/story/components-card--with-no-link