### PR TITLE
Some inline size refactoring

### DIFF
--- a/src/assets/scss/_breakpoints.scss
+++ b/src/assets/scss/_breakpoints.scss
@@ -2,7 +2,13 @@
 
 // Media Queries ///////////////
 @mixin breakpoint($class) {
-  @if $class==xsm {
+  @if $class==xxsm {
+    @media (min-width: $break-xxsm) {
+      @content;
+    }
+  }
+
+  @else if $class==xsm {
     @media (min-width: $break-xsm) {
       @content;
     }
@@ -26,14 +32,14 @@
     }
   }
 
-  @else if $class==page-container {
-    @media (min-width: $break-page-container) {
+  @else if $class==xlg {
+    @media (min-width: $break-xlg) {
       @content;
     }
   }
 
-  @else if $class==xlg {
-    @media (min-width: $break-xlg) {
+  @else if $class==page-container {
+    @media (min-width: $break-page-container) {
       @content;
     }
   }

--- a/src/components/inline/inline.scss
+++ b/src/components/inline/inline.scss
@@ -68,6 +68,13 @@ figure[class*="inline--size-"] {
 
 // Set container query max-width sizes for images.
 @supports (contain: inline-size) {
+  // Adding this to cover the smallest column size.
+  // In most cases, we want to avoid targeting the smallest breakpoint through max-width.
+  @container column (max-width: #{$break-xxsm}) {
+    [class*="inline--size-"] {
+      width: 100%;
+    }
+  }
 
   @container column (min-width: #{$break-xxsm}) {
     .inline--size-small {

--- a/src/components/inline/inline.scss
+++ b/src/components/inline/inline.scss
@@ -8,6 +8,104 @@
   --inline-margin-lg: var(--space-lg-width-gutter);
 }
 
+// === Element media sizes === //
+[class*="inline--size-"] {
+  width: 100%;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  margin-bottom: var(--inline-margin-sm);
+  margin-top: var(--inline-margin-xs);
+
+  &.inline--align-left {
+    margin-inline-end: var(--inline-margin-md);
+  }
+
+  &.inline--align-right {
+    margin-inline-start: var(--inline-margin-md);
+  }
+}
+
+figure[class*="inline--size-"] {
+  img {
+    width: 100%;
+  }
+}
+
+.inline--size-full {
+  margin-bottom: var(--inline-margin-sm);
+  margin-top: var(--inline-margin-xs);
+}
+
+.inline--size-small {
+  @include breakpoint(xxsm) {
+    width: 50%;
+  }
+  @include breakpoint(xsm) {
+    width: 40%;
+  }
+  @include breakpoint(md) {
+    width: 33%;
+  }
+}
+
+.inline--size-medium {
+  @include breakpoint(xsm) {
+    width: 67%;
+  }
+  @include breakpoint(xsm) {
+    width: 50%;
+  }
+}
+
+.inline--size-large {
+  @include breakpoint(md) {
+    width: 70%;
+  }
+  @include breakpoint(lg) {
+    width: 75%;
+  }
+}
+
+// Set container query max-width sizes for images.
+@supports (contain: inline-size) {
+
+  @container column (min-width: #{$break-xxsm}) {
+    .inline--size-small {
+      width: 50%;
+    }
+  }
+
+  @container column (min-width: #{$break-xsm}) {
+    .inline--size-small {
+      width: 40%;
+    }
+    .inline--size-medium {
+      width: 67%;
+    }
+  }
+
+  @container column (min-width: #{$break-md}) {
+    .inline--size-small {
+      width: 33%;
+    }
+
+    .inline--size-medium {
+      width: 50%;
+    }
+
+    .inline--size-large {
+      width: 70%;
+    }
+  }
+
+  @container column (min-width: #{$break-lg}) {
+    .inline--size-large {
+      width: 75%;
+    }
+  }
+}
+// === End: element media sizes === //
+
 // === Element alignment classes  === //
 .inline--align-left {
   float: left;
@@ -26,125 +124,3 @@
   float: right;
 }
 // === End: element alignment classes === //
-
-// === Element media sizes === //
-[class*="inline--size-"] {
-  width: 100%;
-  margin-inline-start: 0;
-  margin-inline-end: 0;
-  margin-bottom: var(--inline-margin-sm);
-  margin-top: var(--inline-margin-xs);
-}
-
-.inline--size-full {
-  margin-bottom: var(--inline-margin-sm);
-  margin-top: var(--inline-margin-xs);
-}
-
-.inline--size-small {
-  @include breakpoint(sm) {
-    width: 35%;
-  }
-}
-
-.inline--size-medium {
-  @include breakpoint(sm) {
-    width: 45%;
-  }
-}
-
-.inline--size-large {
-  @include breakpoint(sm) {
-    width: 55%;
-  }
-}
-
-// Set container query max-width sizes for images.
-@supports (contain: inline-size) {
-  [class*="inline--size-"] {
-    width: 100%;
-  }
-
-  figure[class*="inline--size-"] {
-    img {
-      width: 100%;
-    }
-  }
-
-  @container column (min-width: #{$break-xxsm}) {
-    .inline--size-small {
-      width: 50%;
-
-      &.inline--align-center {
-        margin-inline-start: auto;
-        margin-inline-end: auto;
-      }
-
-      &.inline--align-left {
-        margin-inline-end: var(--inline-margin-md);
-      }
-
-      &.inline--align-right {
-        margin-inline-start: var(--inline-margin-md);
-      }
-    }
-  }
-
-  @container column (min-width: #{$break-xsm}) {
-    .inline--size-small {
-      width: 40%;
-    }
-    .inline--size-medium {
-      width: 67%;
-      margin-inline-start: 0;
-      margin-inline-end: 0;
-
-      &.inline--align-center {
-        margin-inline-start: auto;
-        margin-inline-end: auto;
-      }
-
-      &.inline--align-left {
-        margin-inline-end: var(--inline-margin-md);
-      }
-
-      &.inline--align-right {
-        margin-inline-start: var(--inline-margin-md);
-      }
-    }
-  }
-
-  @container column (min-width: #{$break-md}) {
-    .inline--size-small {
-      width: 33%;
-    }
-
-    .inline--size-medium {
-      width: 50%;
-    }
-
-    .inline--size-large {
-      width: 70%;
-
-      &.inline--align-center {
-        margin-inline-start: auto;
-        margin-inline-end: auto;
-      }
-
-      &.inline--align-left {
-        margin-inline-end: var(--inline-margin-md);
-      }
-
-      &.inline--align-right {
-        margin-inline-start: var(--inline-margin-md);
-      }
-    }
-  }
-
-  @container column (min-width: #{$break-lg}) {
-    .inline--size-large {
-      width: 75%;
-    }
-  }
-}
-// === End: element media sizes === //


### PR DESCRIPTION
Makes the base case (no container queries) more robust by adding more breakpoints and moving some logic from the container query section into the base case.

# To test

This updates the callout alignment, sizing, and margins so that it works without container query code. 
- Test callouts with breakpoints on https://uids.brand.uiowa.edu/latest/?path=/story/elements-inline--three-column and that the callout stretches to 100% when columns get squished. 
- Test with https://github.com/uiowa/uids/blob/4.x/src/components/grid/grid.scss#L66-L72 commented out and verify that sizing and alignment in https://uids.brand.uiowa.edu/latest/?path=/story/elements-inline--narrow still works. 