### PR TITLE
Alerts: updates for uids_base integration

### DIFF
--- a/src/components/alert/Alert.stories.js
+++ b/src/components/alert/Alert.stories.js
@@ -26,6 +26,12 @@ export default {
         category: 'Display options',
       },
     },
+    icon: {
+      name: 'Icon',
+      table: {
+        category: 'Display options',
+      },
+    },
     dismissible: {
       name: 'Dismissible',
       table: {
@@ -57,8 +63,9 @@ const Template = (args) => ({
     <uids-alert
       :type="args.type"
       :centered="args.centered"
+      :icon="args.icon"
       :dismissible="args.dismissible"
-      :centerIconVertically="args.centerIconVertically"
+      :verticallyCentered="args.verticallyCentered"
     >
       <div v-html="args.default"></div>
     </uids-alert>`,
@@ -68,8 +75,9 @@ export const Info = Template.bind({});
 Info.args = {
   type: 'info',
   centered: false,
+  icon: true,
   dismissible: false,
-  centerIconVertically: false,
+  verticallyCentered: false,
   default: `
     <h2 class="headline headline--serif">
       Alert title

--- a/src/components/alert/Alert.stories.js
+++ b/src/components/alert/Alert.stories.js
@@ -26,8 +26,8 @@ export default {
         category: 'Display options',
       },
     },
-    icon: {
-      name: 'Icon',
+    iconVisible: {
+      name: 'Display Icon',
       table: {
         category: 'Display options',
       },
@@ -63,7 +63,7 @@ const Template = (args) => ({
     <uids-alert
       :type="args.type"
       :centered="args.centered"
-      :icon="args.icon"
+      :iconVisible="args.iconVisible"
       :dismissible="args.dismissible"
       :verticallyCentered="args.verticallyCentered"
     >
@@ -75,7 +75,7 @@ export const Info = Template.bind({});
 Info.args = {
   type: 'info',
   centered: false,
-  icon: true,
+  iconVisible: true,
   dismissible: false,
   verticallyCentered: false,
   default: `

--- a/src/components/alert/Alert.vue
+++ b/src/components/alert/Alert.vue
@@ -21,7 +21,13 @@ const props = defineProps({
    */
   centered: {
     type: Boolean,
-    default: false,
+  },
+
+  /**
+   * Icon visible.
+   */
+  icon: {
+    type: Boolean,
   },
 
   /**
@@ -29,7 +35,6 @@ const props = defineProps({
    */
   dismissible: {
     type: Boolean,
-    default: false,
   },
 
   /**
@@ -37,7 +42,6 @@ const props = defineProps({
    */
   verticallyCentered: {
     type: Boolean,
-    default: false,
   }
 });
 
@@ -69,7 +73,7 @@ const classes = computed(() => {
     classes.push('alert--vertically-centered');
   }
 
-  ['centered', 'dismissible'].forEach((prop) => {
+  ['centered', 'dismissible', 'icon'].forEach((prop) => {
     if (props[prop] === true) {
       classes.push(`alert--${ className(prop) }`);
     }
@@ -82,7 +86,7 @@ const classes = computed(() => {
 
 <template>
   <div :class="classes">
-    <div class="alert__icon">
+    <div v-if="props.icon" class="alert__icon">
       <span class="fa-stack fa-1x"><span role="presentation" class="fas fa-circle fa-stack-2x"></span><span role="presentation" :class="'fas fa-stack-1x fa-inverse fa-' + icon"></span></span>
     </div>
     <slot class="alert__content" name="default">Body</slot>

--- a/src/components/alert/Alert.vue
+++ b/src/components/alert/Alert.vue
@@ -26,7 +26,7 @@ const props = defineProps({
   /**
    * Icon visible.
    */
-  icon: {
+  iconVisible: {
     type: Boolean,
   },
 
@@ -73,7 +73,11 @@ const classes = computed(() => {
     classes.push('alert--vertically-centered');
   }
 
-  ['centered', 'dismissible', 'icon'].forEach((prop) => {
+  if (props.iconVisible) {
+    classes.push('alert--icon');
+  }
+
+  ['centered', 'dismissible'].forEach((prop) => {
     if (props[prop] === true) {
       classes.push(`alert--${ className(prop) }`);
     }
@@ -86,7 +90,7 @@ const classes = computed(() => {
 
 <template>
   <div :class="classes">
-    <div v-if="props.icon" class="alert__icon">
+    <div v-if="props.iconVisible" class="alert__icon">
       <span class="fa-stack fa-1x"><span role="presentation" class="fas fa-circle fa-stack-2x"></span><span role="presentation" :class="'fas fa-stack-1x fa-inverse fa-' + icon"></span></span>
     </div>
     <slot class="alert__content" name="default">Body</slot>

--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -8,7 +8,6 @@
   --h2-font-size: 1.6rem;
   @include border;
   padding: 1.5rem;
-  display: flex;
   line-height: 1.3;
   font-size: $content-font-size;
 
@@ -129,6 +128,11 @@
     }
   }
 }
+
+.alert--icon {
+  display: flex;
+}
+
 // === End: Alert dismissible === //
 
 // === End: Modifiers === //

--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -32,7 +32,7 @@
     margin-bottom: 0;
 
     & + *:not(span):not(div):not(svg) {
-      margin-top: .1rem;
+      margin-top: .2rem;
       line-height: 1.6;
     }
   }

--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -32,7 +32,7 @@
     margin-bottom: 0;
 
     & + *:not(span):not(div):not(svg) {
-      margin-top: .4rem;
+      margin-top: .1rem;
       line-height: 1.3;
     }
   }

--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -33,7 +33,7 @@
 
     & + *:not(span):not(div):not(svg) {
       margin-top: .1rem;
-      line-height: 1.3;
+      line-height: 1.6;
     }
   }
 }

--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -7,6 +7,7 @@
 .alert {
   --h2-font-size: 1.6rem;
   @include border;
+  border-radius: 2px;
   padding: 1.5rem;
   line-height: 1.3;
   font-size: $content-font-size;

--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -129,11 +129,12 @@
     }
   }
 }
+// === End: Alert dismissible === //
 
+// === Alert icon flex property === //
 .alert--icon {
   display: flex;
 }
-
-// === End: Alert dismissible === //
+// === End: Alert icon flex property === //
 
 // === End: Modifiers === //

--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -41,7 +41,7 @@
 
 // === Alert Icon === //
 .alert__icon {
-  padding: 0 $lg 0 0;
+  padding: 0  1.5rem 0 0;
 
   .fa-stack {
     width: 2em;


### PR DESCRIPTION
Work for https://github.com/uiowa/uiowa/pull/6810

# How to test

- Review the `alert--icon` modifier class that is providing the `display: flex` property to the alert that allows the icon and alert content to display the side by side.  This modifier was added because when alerts are added in the SiteNow WYSIWYG they are not enclosed in a `<div>` wrapper and the `display: flex` that was previously added by default to the `.alert`class rendered the alert text as unreadable. 

Basically, this format of alert below needs to work:
```
<div class="alert alert--info">Alert text</div>
```