### PR TITLE
Change location pointed to by 3.x components

### DIFF
--- a/src/components/utlity.ts
+++ b/src/components/utlity.ts
@@ -2,4 +2,4 @@ export function className(text: string): string {
   return text.replace(/_/g, '-');
 }
 
-export  const V3_BASE_URL = 'https://uids.brand.uiowa.edu/';
+export  const V3_BASE_URL = 'https://uids.brand.uiowa.edu/docs/v3.6.21/';

--- a/src/components/utlity.ts
+++ b/src/components/utlity.ts
@@ -2,4 +2,4 @@ export function className(text: string): string {
   return text.replace(/_/g, '-');
 }
 
-export  const V3_BASE_URL = 'https://uids.brand.uiowa.edu/docs/v3.6.21/';
+export  const V3_BASE_URL = 'https://uids.brand.uiowa.edu/3.x/';


### PR DESCRIPTION
Another piece of #892. Updated linked location of 3.x components to uids.brand.uiowa.edu/3.x/