### PR TITLE
3.x Fix build process so 3.x branches successfully build to 3.x directory

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,11 +17,10 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]".
-    # Otherwise, clone it normally. Also, skip the 3.x branch, so we don't build that to latest anymore.
+    # Otherwise, clone it normally.
     if: |
-      ((github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
-      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]'))
-      && github.ref != 'refs/heads/3.x'
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]')
+      || (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     env:
       TARGET_BRANCH: gh-pages
       MAIN_BRANCH: 3.x


### PR DESCRIPTION
Yet another piece of #892. 

Removed code previously added to stop 3.x from building to /latest, in case it is also blocking us from building to /3.x.