### PR TITLE
Refactoring to always have access to the UIowa colors.

### DIFF
--- a/src/scss/abstracts/_variables.scss
+++ b/src/scss/abstracts/_variables.scss
@@ -1,5 +1,7 @@
 // Utility color variables
 
+$uiowa-gold: var(--uiowa-gold);
+$uiowa-black: var(--uiowa-black);
 $primary: var(--brand-primary);
 $secondary: var(--brand-secondary);
 $light: #f3f3f3;

--- a/src/scss/components/logo.scss
+++ b/src/scss/components/logo.scss
@@ -41,7 +41,7 @@
 }
 
 .logo-icon {
-  fill: $primary;
+  fill: $uiowa-gold;
   height: 20px;
 
   @include breakpoint(md) {

--- a/src/scss/uids-core.scss
+++ b/src/scss/uids-core.scss
@@ -13,8 +13,11 @@
 
 :root {
   // Colors
-  --brand-primary: #FFCD00;
-  --brand-secondary: #000000;
+  --uiowa-gold: #FFCD00;
+  --uiowa-black: #000000;
+  --brand-primary: var(--uiowa-gold);
+  --brand-secondary: var(--uiowa-black);
+
   // Margin/Padding
   --space-lg-width-gutter: 3rem;
   --space-md-width-gutter: 2rem;


### PR DESCRIPTION
This should do nothing at all to UIDS, but allow the logo to always be gold, even when the primary colors change.
