### PR TITLE
[Card] margin adjustment for subtitle

### DIFF
--- a/src/scss/components/card.scss
+++ b/src/scss/components/card.scss
@@ -236,12 +236,13 @@
   font-size: 1.3rem;
   font-weight: $font-weight-medium;
   line-height: 1.4;
+  margin-top: -0.4rem;
 }
 // === End: Subtitle === //
 
 // === Details === //
 .card__details {
-  margin: -0.4rem 0 $sm;
+  margin: 0 0 $sm;
 }
 // === End: Details === //
 


### PR DESCRIPTION
This pr moves the negative margin to the card__subtitle so that when cards with title + meta are used, they won't be so close together.  

# How to test 
- On `/?path=/story/components-card--person-profile` confirm that subtitle spacing matches https://uids.brand.uiowa.edu/latest/?path=/story/components-card--person-profile.   
- Remove subtitle and add meta text and compare against https://uids.brand.uiowa.edu/latest/?path=/story/components-card--person-profile and confirm that there is a little extra spacing between title and meta fields. 