### PR TITLE
Card Pre-title

### DIFF
--- a/src/components/card/Card.stories.js
+++ b/src/components/card/Card.stories.js
@@ -243,8 +243,8 @@ const Template = (args) => ({
             :media_padded="args.media_padded"
             :centered="args.centered"
           >
-            <template #pre_title v-if="args.pre_title"><span v-html="args.pre_title"></span></template>
             <template #media v-if="args.media"><span v-html="args.media" ></span></template>
+            <template #pre_title v-if="args.pre_title"><span v-html="args.pre_title"></span></template>
             <template #title v-if="args.title"><div v-html="args.title" ></div></template>
             <template #subtitle v-if="args.subtitle"><div v-html="args.subtitle" ></div></template>
             <template #meta v-if="args.meta"><div v-html="args.meta" ></div></template>
@@ -260,6 +260,7 @@ export const Default = Template.bind({});
 // More on args: https://storybook.js.org/docs/vue/writing-stories/args
 Default.args = {
   media: '<img src="' + card_image + '" alt="Alt">',
+  pre_title: '',
   title: 'Arts and Culture',
   subtitle: '',
   meta: '',

--- a/src/components/card/Card.stories.js
+++ b/src/components/card/Card.stories.js
@@ -21,6 +21,13 @@ export default {
   tags: ['autodocs'],
   argTypes: {
     // Props
+    pre_title: {
+      name: 'Pre Title',
+      control: { type: 'text' },
+      table: {
+        category: 'Content',
+      },
+    },
     headline_style: {
       name: 'Title style',
       options: ['serif', ''],
@@ -236,6 +243,7 @@ const Template = (args) => ({
             :media_padded="args.media_padded"
             :centered="args.centered"
           >
+            <template #pre_title v-if="args.pre_title"><span v-html="args.pre_title"></span></template>
             <template #media v-if="args.media"><span v-html="args.media" ></span></template>
             <template #title v-if="args.title"><div v-html="args.title" ></div></template>
             <template #subtitle v-if="args.subtitle"><div v-html="args.subtitle" ></div></template>
@@ -363,6 +371,12 @@ export const ButtonAlignedToBottom = Template.bind({})
 ButtonAlignedToBottom.args = {
   ...Default.args,
   button_align_bottom: true,
+}
+
+export const PreTitle = Template.bind({})
+PreTitle.args = {
+  ...Default.args,
+  pre_title: '<span role="presentation" class="fas fa-solid fa-thumbtack"></span> Pinned',
 }
 
 const GridTemplate = (args) => ({

--- a/src/components/card/Card.stories.js
+++ b/src/components/card/Card.stories.js
@@ -22,7 +22,7 @@ export default {
   argTypes: {
     // Props
     pre_title: {
-      name: 'Pre Title',
+      name: 'Pre-title',
       control: { type: 'text' },
       table: {
         category: 'Content',

--- a/src/components/card/Card.vue
+++ b/src/components/card/Card.vue
@@ -211,6 +211,9 @@ onMounted(() => {
     </div>
 
     <div class="card__body">
+      <div v-if="$slots.pre_title" class="card__pre-title">
+        <slot name="pre_title"></slot>
+      </div>
       <header v-if="$slots.title">
         <uids-headline :text_style="headline_style">
           <!-- @slot The title of the card. HTML is allowed. -->

--- a/src/scss/components/card.scss
+++ b/src/scss/components/card.scss
@@ -233,6 +233,11 @@
 .card__pre-title {
   font-size: 0.75rem;
   color: $med-gray;
+   i,
+  span[class*="fa-"],
+  svg {
+    margin-right: .2rem;
+  }
 }
 // === End: Pre-Title === //
 

--- a/src/scss/components/card.scss
+++ b/src/scss/components/card.scss
@@ -229,6 +229,13 @@
 
 // === End: Media === //
 
+// === Pre-Title === //
+.card__pre-title {
+  font-size: 0.75rem;
+  color: $med-gray;
+}
+// === End: Pre-Title === //
+
 // === Subtitle === //
 .card__subtitle {
   opacity: .7;


### PR DESCRIPTION
<img width="955" alt="Screenshot 2024-11-01 at 11 22 31 AM" src="https://github.com/user-attachments/assets/6a271480-3655-473e-b9a7-e695ee0b3a3e">

easy peasy?!

# Test

- `nvm use`
- `yarn install`
- `yarn storybook`
- Go to the card component and see the pretitle story. See the pinned icon and text.
- Check the code for proper naming conventions and such?