### PR TITLE
Remove land acknowledgment

### DIFF
--- a/src/components/brand-footer/BrandFooter.vue
+++ b/src/components/brand-footer/BrandFooter.vue
@@ -63,9 +63,6 @@ export default {
             <li>
               <a href="https://uiowa.edu/accessibility">Accessibility</a>
             </li>
-            <li>
-              <a href="https://nativeamericancouncil.org.uiowa.edu">UI Indigenous Land Acknowledgement</a>
-            </li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Related to https://github.com/uiowa/uiowa/issues/8355

## Test
```
yarn storybook
```
- Confirm that the brand footer does not contain the link to the the land acknowledgement.