### PR TITLE
[Banner] Changes after more testing in uids_base

### DIFF
--- a/src/scss/components/banner.scss
+++ b/src/scss/components/banner.scss
@@ -843,6 +843,8 @@
     z-index: 1;
 
     a {
+      color: #fff;
+
       &:hover {
         text-decoration: none;
       }

--- a/src/scss/components/slider.scss
+++ b/src/scss/components/slider.scss
@@ -58,7 +58,7 @@
       }
     }
 
-    .banner__image img {
+    .media--image img {
       display: block;
       width: 100%;
       -o-object-fit: cover;


### PR DESCRIPTION
# How to test
- `yarn storybook`
- Compare http://localhost:6006/?path=/story/components-banner--background-image&args=mobile_content_below_image:!false  against https://uids.brand.uiowa.edu/latest/?path=/story/components-banner--background-image&args=mobile_content_below_image:!false.  Check out the banner on mobile.  Confirm the headline is white instead of black on mobile. 
- Try adjusting background combinations and controls and look for any other issues with color contrast. 

This pr sets the banner headline `<a>` to white by default and then is overridden in by all other background color and gradient variants.  In https://github.com/uiowa/uids/pull/950, we removed the `headline--negative` class which was used to set the headline color on dark backgrounds.  