### PR TITLE
Accordion - Accessibility tweaks

### DIFF
--- a/src/assets/js/accordion.js
+++ b/src/assets/js/accordion.js
@@ -46,10 +46,6 @@ class Accordion {
    */
   toggleAccordionItem(accordionItem, isOpening) {
 
-    // Set the relevant attributes for 'accordion' based on 'open'.
-    accordionItem.setAttribute('aria-expanded', isOpening);
-    accordionItem.setAttribute('aria-selected', isOpening);
-
     // Check if the accordion was clicked.
     const clicked = accordionItem.getAttribute('data-accordion-clicked');
     if (clicked) {

--- a/src/components/accordion/Accordion.vue
+++ b/src/components/accordion/Accordion.vue
@@ -47,19 +47,18 @@ onMounted(() => {
   <div
     :class="accordionClasses"
     role="tablist"
+    :aria-multiselectable="props.multiselectable ? 'true' : 'false'"
     :aria-owns="ariaOwnsIds()"
   >
     <details v-for="(item, index) in props.items"
       :key="index"
       class="accordion__item"
-      :aria-labelledby="'accordion-heading-' + index"
       :name="!props.multiselectable ? 'accordion-collection' : null"
       :open="item.open"
       :id="'accordion-item-' + index"
+      role="none"
     >
       <summary :id="'accordion-heading-' + index" class="accordion__heading"
-        :aria-expanded="item.open ? 'true' : 'false'"
-        :aria-selected="item.open ? 'true' : 'false'"
         role="tab"
       >
         <h2>
@@ -70,7 +69,6 @@ onMounted(() => {
       <div
         :id="'accordion-content-' + index"
         class="accordion__content"
-        :aria-labelledby="'accordion-heading-' + index"
         v-html="item.content"
       ></div>
     </details>


### PR DESCRIPTION
Resolves https://github.com/uiowa/uids/issues/961

Same test instructions from https://github.com/uiowa/uids/pull/955 should apply but should also pass accessibility tool scans from AInspector (Firefox), WAVE, Lighthouse/Axe, SiteImprove

# To test
1. Code review
2. Check to see that you can using `cmd + f` to search inside closed accordions.
3. Test single- and multi-selectable functionality.
4. Confirm that most recently clicked accordion item's heading ID becomes the URL hash fragment.
5. Confirm that loading a particular accordion as open via URL hash fragment works.
6. Ensure that accordions can be navigated using VoiceOver. VO should report the accordion items as `x of 4` and their initial state as expanded or collapsed. When using `ctrl + option + space` to "activate" an accordion item, VO should report the items new state as collapsed or expanded.

ProTip: To make testing with VoiceOver easier, click the "Open canvas in new tab" button to get the component more or less by itself.