### PR TITLE
Accordion - Support other heading sizes

### DIFF
--- a/src/scss/components/accordion.scss
+++ b/src/scss/components/accordion.scss
@@ -40,7 +40,7 @@
     }
   }
 
-  .accordion__heading h2 {
+  .accordion__heading :is(h2, h3, h4, h5, h6) {
     all: inherit;
     display: flex;
     font-size: $content-font-size;


### PR DESCRIPTION
Because our collection block in uiowa supports parent/child heading nesting, accordions could have different heading sizes and these should be accounted for in the styles.

# Test

- Pull down and inspect an accordion element. Change the DOM for the accordion from h2 to h3 or greater. See that the styles don't break with the change. Aka, you don't want to see the following:

<img width="429" alt="Screenshot 2025-01-13 at 9 38 43 AM" src="https://github.com/user-attachments/assets/c839f61e-6168-4bbb-8cac-478db0038edc" />
