### PR TITLE
Accordion - move icon stuff into summary, consolidate rules

### DIFF
--- a/src/scss/components/accordion.scss
+++ b/src/scss/components/accordion.scss
@@ -12,16 +12,30 @@
   $accordion-grey: #edeceb;
   --accordion-grey: #{$accordion-grey};
 
-  summary {
-    list-style: none;
-  }
-
   details {
     &[open] {
-      i, svg {
-        transform: rotate(0deg) translate(0px, 0.1em);
-        background-color: #fafafa;
+      summary {
+        i, svg {
+          transform: rotate(0deg) translate(0px, 0.1em);
+          background-color: #fafafa;
+        }
       }
+    }
+  }
+
+  summary {
+    list-style: none;
+    width: 100%;
+    background-color: var(--accordion-grey);
+    display: flex;
+    cursor: pointer;
+
+    &:hover, &:focus {
+      background-color: color.scale($accordion-grey, $lightness: -4%);
+    }
+
+    &::-webkit-details-marker {
+      visibility: hidden;
     }
 
     i, svg {
@@ -54,21 +68,6 @@
 
     &:focus {
       outline: 2px auto -webkit-focus-ring-color;
-    }
-  }
-
-  summary {
-    width: 100%;
-    background-color: var(--accordion-grey);
-    display: flex;
-    cursor: pointer;
-
-    &:hover, &:focus {
-      background-color: color.scale($accordion-grey, $lightness: -4%);
-    }
-
-    &::-webkit-details-marker {
-      visibility: hidden;
     }
   }
 


### PR DESCRIPTION
https://github.com/uiowa/uiowa/pull/8405#issuecomment-2604972351

I don't have an easy way to test this in UIDS but by moving the icon styles under summary, it prevents it from changing icons elsewhere in the details element which contains the accordion body.

# To Test

Ensure the UIDS version is still working as expected. The icon rotates and is positioned correctly when the accordion item is expanded, collapsed.