### PR TITLE
Added fix for circle lists

### DIFF
--- a/src/scss/base/_lists.scss
+++ b/src/scss/base/_lists.scss
@@ -120,6 +120,7 @@ dd {
       font-weight: bold;
       font-size: 2.4rem;
       line-height: 0;
+      box-sizing: border-box;
 
       @include utilities.breakpoint(sm) {
         position: absolute;


### PR DESCRIPTION
Resolves https://github.com/uiowa/uids/issues/976. 

# How to test

Add this code inside the `Accordion.stories.js` file and confirm that circles are rendering as expected:

```
<ul class="element--circle-list ">
    <li>
        In fermentum leo eu lectus quis dictum mi aliquet.
    </li>
    <li>
        Morbi eu nulla lobortis, lobortis est in, fringilla felis.
    </li>
    <li>
        Aliquam nec felis in sapien fermentum nec lectus.
    </li>
    <li>
        Ut non enim metus.
    </li>
</ul>
```