### PR TITLE
Removed padding for pre_title underlined style

### DIFF
--- a/src/scss/components/banner.scss
+++ b/src/scss/components/banner.scss
@@ -207,6 +207,7 @@
   }
 
   &.headline.headline--underline {
+    padding-bottom: 0;
     &:after {
       display: none;
     }


### PR DESCRIPTION
This pr removes pre_title padding that was missed in the previous update to make the underline style available in the banner. 