### PR TITLE
adjust stat and table as it relates to all caps text

### DIFF
--- a/src/components/stat/Stat.vue
+++ b/src/components/stat/Stat.vue
@@ -66,7 +66,7 @@ const classes = computed(() => {
       </h2>
     </div>
 
-    <p v-if="stat_summary" class="stat__description" v-html="stat_summary"></p>
+    <span v-if="stat_summary" class="stat__description" v-html="stat_summary"></span>
 
     <p v-if="stat_content" class="stat__content" v-html="stat_content"></p>
   </div>

--- a/src/scss/components/stat.scss
+++ b/src/scss/components/stat.scss
@@ -130,6 +130,7 @@
 
   &__description {
     position: relative;
+    display: inline-block;
     font-family: variables.$font-family-caps-bold;
     font-weight: bold;
     text-transform: uppercase;

--- a/src/scss/components/tables.scss
+++ b/src/scss/components/tables.scss
@@ -72,7 +72,6 @@ table {
   thead th {
     background-color: variables.$primary;
     border: none;
-    text-transform: capitalize;
     a {
       color: variables.$secondary;
       [class*="bg--"] & {
@@ -110,7 +109,6 @@ table {
     text-align: center;
     font-size: 1rem;
     color: #fff;
-    text-transform: capitalize;
     background-color: #333;
     font-weight: bold;
     a,

--- a/src/scss/components/tables.scss
+++ b/src/scss/components/tables.scss
@@ -72,17 +72,12 @@ table {
   thead th {
     background-color: variables.$primary;
     border: none;
-    text-transform: lowercase;
     a {
       color: variables.$secondary;
       [class*="bg--"] & {
         color: variables.$secondary;
       }
     }
-  }
-  // Sentence-case hack.
-  thead th:first-letter {
-    text-transform: uppercase;
   }
 
   tbody th {

--- a/src/scss/components/tables.scss
+++ b/src/scss/components/tables.scss
@@ -72,12 +72,17 @@ table {
   thead th {
     background-color: variables.$primary;
     border: none;
+    text-transform: lowercase;
     a {
       color: variables.$secondary;
       [class*="bg--"] & {
         color: variables.$secondary;
       }
     }
+  }
+  // Sentence-case hack.
+  thead th:first-letter {
+    text-transform: uppercase;
   }
 
   tbody th {

--- a/src/scss/components/tables.scss
+++ b/src/scss/components/tables.scss
@@ -72,7 +72,7 @@ table {
   thead th {
     background-color: variables.$primary;
     border: none;
-    text-transform: uppercase;
+    text-transform: capitalize;
     a {
       color: variables.$secondary;
       [class*="bg--"] & {
@@ -110,7 +110,7 @@ table {
     text-align: center;
     font-size: 1rem;
     color: #fff;
-    text-transform: uppercase;
+    text-transform: capitalize;
     background-color: #333;
     font-weight: bold;
     a,


### PR DESCRIPTION
Relates to https://github.com/uiowa/uiowa/pull/9304

See https://github.com/uiowa/uiowa/pull/9304 for testing instructions.

~~`capitalize` is i think the only css option here. so if `BIG AND BOLD` is the value, it will respect it and leave it as all caps. If the value starts with a lower case letter `living On Campus - Example Table` it will change it to `Living On Campus - Example Table`~~ though this is true, not the way to move forward with this.