### PR TITLE
[Tables] Switched to max-height to pass Siteimprove scan

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -41,7 +41,7 @@ const tableClasses = computed(() => {
 </script>
 
 <template>
-  <div class="table-responsive" :class="{ 'table--sticky': props.sticky }">
+  <div class="table-responsive" :class="{ 'table-sticky': props.sticky }">
     <table :class="tableClasses" class="table" :summary="summary">
       <caption>{{ caption }}</caption>
       <thead>

--- a/src/scss/components/tables.scss
+++ b/src/scss/components/tables.scss
@@ -150,7 +150,7 @@ table {
   }
 
   &.table-sticky {
-    height: 80vh;
+    max-height: 80vh;
 
     thead {
       position: sticky;


### PR DESCRIPTION
Related to https://github.com/uiowa/uiowa/issues/9366. 

- Undo the file change for `max-height` and run the Siteimprove plugin on http://localhost:6006/iframe.html?globals=&args=&id=components-table--default&viewMode=story.  Confirm you see the "Scrollable element is not keyboard accessible" issue. 
- Redo the file change and test the page again and the error should be gone. 
- Review https://github.com/uiowa/uiowa/pull/9398. 
- A11y fix taken from `max-height` example from https://codepen.io/aardrian/pen/VwYyVJY from https://adrianroselli.com/2020/01/fixed-table-headers.html.