### PR TITLE
Scope video script to banner only

### DIFF
--- a/src/assets/js/video.js
+++ b/src/assets/js/video.js
@@ -6,7 +6,7 @@
   function Video(element, index) {
     if (element) {
       this.element = element;
-      this.video = this.element.querySelector('video');
+      this.video = this.element.querySelector('.banner video');
       if (this.video) {
         // Give each video an id so that we can index them individually later.
         // As well, no two elements should have the same ID, so assigning them like this ensures that is the case.


### PR DESCRIPTION
# Motivation

The video is not scoped to the banner component, but it was never really intended to be applied to other videos. This PR scopes the script so that only banner videos are targeted.

# How to test

```
nvm use && yarn storybook
```
- http://localhost:6006/?path=/story/components-banner--background-video
- Confirm that video still functions as expected.
- To check that this fixes the console error on the homepage site, you can manually make the same change to the docroot/themes/custom/uids_base/uids/assets/js/video.js file in the SiteNow repo and check it locally.