### PR TITLE
5.x - Make UIDS consumable (package.json) and adjust token names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@uiowa/uids",
+  "version": "5.0.0-alpha.0",
+  "description": "Iowa Design System",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/uiowa/uids.git"
+  },
+  "exports": {
+    ".": "./tokens.css"
+  },
+  "files": [
+    "tokens.css"
+  ]
+}

--- a/tokens.css
+++ b/tokens.css
@@ -1,28 +1,28 @@
-/* IDS 5.x Design Tokens — see #1049 */
+/* Iowa Design System — 5.x design tokens (see #1049) */
 
 :root {
   /* === Color primitives === */
-  --ids-gold:     #FFCD00;
-  --ids-black:    #000000;
-  --ids-white:    #FFFFFF;
-  --ids-blue:     #00558C;
-  --ids-gray-100: #F3F3F3;
-  --ids-gray-500: #63666A;
+  --uids-color-gold:     #FFCD00;
+  --uids-color-black:    #000000;
+  --uids-color-white:    #FFFFFF;
+  --uids-color-blue:     #00558C;
+  --uids-color-gray-100: #F3F3F3;
+  --uids-color-gray-500: #63666A;
 
   /* === Color semantics === */
-  --ids-color-text:       var(--ids-black);
-  --ids-color-background: var(--ids-white);
-  --ids-color-link:       var(--ids-blue);
-  --ids-color-brand:      var(--ids-gold);
+  --uids-color-text:       var(--uids-color-black);
+  --uids-color-background: var(--uids-color-white);
+  --uids-color-link:       var(--uids-color-blue);
+  --uids-color-brand:      var(--uids-color-gold);
 
   /* === Typography primitives === */
-  --ids-font-family-sans:  'Roboto', sans-serif;
-  --ids-font-family-serif: 'Zilla Slab', 'Zilla-fallback', serif;
-  --ids-font-size-100: 1rem;
-  --ids-font-size-200: 1.25rem;
+  --uids-font-family-sans:  'Roboto', sans-serif;
+  --uids-font-family-serif: 'Zilla Slab', 'Zilla-fallback', serif;
+  --uids-font-size-100: 1rem;
+  --uids-font-size-200: 1.25rem;
 
   /* === Typography semantics === */
-  --ids-font-family-body:    var(--ids-font-family-sans);
-  --ids-font-family-heading: var(--ids-font-family-serif);
-  --ids-font-size-body:      var(--ids-font-size-100);
+  --uids-font-family-body:    var(--uids-font-family-sans);
+  --uids-font-family-heading: var(--uids-font-family-serif);
+  --uids-font-size-body:      var(--uids-font-size-100);
 }

--- a/tokens.css
+++ b/tokens.css
@@ -2,27 +2,27 @@
 
 :root {
   /* === Color primitives === */
-  --uids-color-gold:     #FFCD00;
-  --uids-color-black:    #000000;
-  --uids-color-white:    #FFFFFF;
-  --uids-color-blue:     #00558C;
-  --uids-color-gray-100: #F3F3F3;
-  --uids-color-gray-500: #63666A;
+  --uiowa-color-gold:     #FFCD00;
+  --uiowa-color-black:    #000000;
+  --uiowa-color-white:    #FFFFFF;
+  --uiowa-color-blue:     #00558C;
+  --uiowa-color-gray-100: #F3F3F3;
+  --uiowa-color-gray-500: #63666A;
 
   /* === Color semantics === */
-  --uids-color-text:       var(--uids-color-black);
-  --uids-color-background: var(--uids-color-white);
-  --uids-color-link:       var(--uids-color-blue);
-  --uids-color-brand:      var(--uids-color-gold);
+  --uiowa-color-text:       var(--uiowa-color-black);
+  --uiowa-color-background: var(--uiowa-color-white);
+  --uiowa-color-link:       var(--uiowa-color-blue);
+  --uiowa-color-brand:      var(--uiowa-color-gold);
 
   /* === Typography primitives === */
-  --uids-font-family-sans:  'Roboto', sans-serif;
-  --uids-font-family-serif: 'Zilla Slab', 'Zilla-fallback', serif;
-  --uids-font-size-100: 1rem;
-  --uids-font-size-200: 1.25rem;
+  --uiowa-font-family-sans:  'Roboto', sans-serif;
+  --uiowa-font-family-serif: 'Zilla Slab', 'Zilla-fallback', serif;
+  --uiowa-font-size-100: 1rem;
+  --uiowa-font-size-200: 1.25rem;
 
   /* === Typography semantics === */
-  --uids-font-family-body:    var(--uids-font-family-sans);
-  --uids-font-family-heading: var(--uids-font-family-serif);
-  --uids-font-size-body:      var(--uids-font-size-100);
+  --uiowa-font-family-body:    var(--uiowa-font-family-sans);
+  --uiowa-font-family-heading: var(--uiowa-font-family-serif);
+  --uiowa-font-size-body:      var(--uiowa-font-size-100);
 }


### PR DESCRIPTION
**package.json** — minimal manifest for the 5.x tokens POC.

- \`name\`: \`@uiowa/uids\` — scoped.
- \`version\`: \`5.0.0-alpha.0\` — follows 4.x's alpha convention.
- \`exports\`: maps root to \`./tokens.css\` so consumers \`import '@uiowa/uids'\` without depending on the internal filename.
- \`files\`: allowlists \`tokens.css\` only — anything else added later won't accidentally ship.

**tokens.css** — naming refinements.

- CSS variable prefix is \`--uiowa-\` per brand team direction (matches the existing 4.x convention).
- Color primitives carry the \`color\` bucket (\`--uiowa-color-gold\`, \`--uiowa-color-black\`, etc.) — matches the typography pattern where primitives also include their bucket. Self-documenting and scales cleanly.

Context: #1049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)