### PR TITLE
Cta headline font-weight update

### DIFF
--- a/src/components/cta/Cta.stories.js
+++ b/src/components/cta/Cta.stories.js
@@ -94,7 +94,7 @@ const Template = (args) => ({
       :orientation="args.orientation"
     >
     <template #details v-if="args.details"><div v-html="args.details" ></div></template>
-    <template #title v-if="args.title"><div :class="getClasses" v-html="args.title" ></div></template>
+    <template #title v-if="args.title">{{ args.title }}</template>
     <template #button_icon v-if="args.button_icon"><span v-html="args.button_icon" ></span></template>
     </uids-cta>
   `,

--- a/src/components/cta/Cta.vue
+++ b/src/components/cta/Cta.vue
@@ -74,7 +74,7 @@ const buttonClasses = computed(() => {
       <div class="cta__title" v-if="$slots.title">
         <uids-headline :text_style="headline_style">
           <!-- @slot The title of the card. HTML is allowed. -->
-          <slot name="title">Title</slot>
+          <span class="headline__heading"><slot name="title">Title</slot></span>
         </uids-headline>
       </div>
       <div class="cta__content" v-if="details" >

--- a/src/scss/components/_headline.scss
+++ b/src/scss/components/_headline.scss
@@ -51,14 +51,6 @@
   @include headline-mixins.headline-highlight-word;
 }
 
-.bold-headline--caps .headline__heading,
-.headline--uppercase .headline__heading,
-.headline--uppercase .headline__text {
-  [class*="bg--gold"] & {
-    font-weight: 400;
-  }
-}
-
 .bold-headline--caps .headline__heading span,
 .headline--uppercase .headline__heading span,
 .headline--uppercase .headline__text span {


### PR DESCRIPTION
Resolves **Different font weights used for the CTA headline** - https://github.com/uiowa/uiowa/issues/9934

I also included an update to the CTA headline html to match production.

```
<h2 class="headline headline--uppercase">
  <span class="headline__heading">Be a Hawkeye</span>
</h2>
```

### How to test CTA headline
- `yarn storybook`
- go to Components → CTA
- update title style to Antonio (default)
- Confirm the rendered markup is:
```
<div class="cta__title">
  <h2 class="headline headline--uppercase">
    <span class="headline__heading">Be a Hawkeye</span>
  </h2>
</div>
```
- Switch the background color to all the options (black,gold,gray,white) and check that the headline font-weight is 700 for all options.
- Verify on all other orientation variants of CTA ( inline, center, left)

### How to test Banner headline
- `yarn storybook`
- navigate to Banner → Background pattern
- Under headline, change the text_style to "uppercase". http://localhost:6006/?path=/story/components-banner--background-pattern&args=background:gold;headline.text_style:uppercase
- Cycle through the background options (gold, black, gray, etc..) check to verify that the headline font-weight is 700 for all options.